### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,22 @@ composer](http://getcomposer.org).
 <?php
 
 use React\Async\Util as Async;
-
-$loop = React\EventLoop\Factory::create();
+use React\EventLoop\Loop;
 
 Async::parallel(
     array(
-        function ($callback, $errback) use ($loop) {
-            $loop->addTimer(1, function () use ($callback) {
+        function ($callback, $errback) {
+            Loop::addTimer(1, function () use ($callback) {
                 $callback('Slept for a whole second');
             });
         },
-        function ($callback, $errback) use ($loop) {
-            $loop->addTimer(1, function () use ($callback) {
+        function ($callback, $errback) {
+            Loop::addTimer(1, function () use ($callback) {
                 $callback('Slept for another whole second');
             });
         },
-        function ($callback, $errback) use ($loop) {
-            $loop->addTimer(1, function () use ($callback) {
+        function ($callback, $errback) {
+            Loop::addTimer(1, function () use ($callback) {
                 $callback('Slept for yet another whole second');
             });
         },
@@ -75,8 +74,6 @@ Async::parallel(
         throw $e;
     }
 );
-
-$loop->run();
 ```
 
 ### Waterfall
@@ -85,16 +82,15 @@ $loop->run();
 <?php
 
 use React\Async\Util as Async;
+use React\EventLoop\Loop;
 
-$loop = React\EventLoop\Factory::create();
-
-$addOne = function ($prev, $callback = null) use ($loop) {
+$addOne = function ($prev, $callback = null) {
     if (!$callback) {
         $callback = $prev;
         $prev = 0;
     }
 
-    $loop->addTimer(1, function () use ($prev, $callback) {
+    Loop::addTimer(1, function () use ($prev, $callback) {
         $callback($prev + 1);
     });
 };
@@ -108,8 +104,6 @@ Async::waterfall(array(
         $callback();
     },
 ));
-
-$loop->run();
 ```
 
 ## Todo

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^4.8.35",
-        "react/event-loop": "0.2.*"
+        "react/event-loop": "^1.2"
     },
     "suggest": {
-        "react/event-loop": "You need some kind of event loop for this to make sense."
+        "react/event-loop": "You need an event loop for this to make sense."
     },
     "autoload": {
         "psr-4": { "React\\Async\\": "src/" }

--- a/tests/UtilParallelTest.php
+++ b/tests/UtilParallelTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Async;
 
 use React\Async\Util;
+use React\EventLoop\Loop;
 
 class UtilParallelTest extends TestCase
 {
@@ -18,16 +19,14 @@ class UtilParallelTest extends TestCase
 
     public function testParallelWithTasks()
     {
-        $loop = new \React\EventLoop\StreamSelectLoop();
-
         $tasks = array(
-            function ($callback, $errback) use ($loop) {
-                $loop->addTimer(0.1, function () use ($callback) {
+            function ($callback, $errback) {
+                Loop::addTimer(0.1, function () use ($callback) {
                     $callback('foo');
                 });
             },
-            function ($callback, $errback) use ($loop) {
-                $loop->addTimer(0.1, function () use ($callback) {
+            function ($callback, $errback) {
+                Loop::addTimer(0.1, function () use ($callback) {
                     $callback('bar');
                 });
             },
@@ -41,7 +40,7 @@ class UtilParallelTest extends TestCase
         $timer = new Timer($this);
         $timer->start();
 
-        $loop->run();
+        Loop::run();
 
         $timer->stop();
         $timer->assertInRange(0.1, 0.2);
@@ -78,15 +77,13 @@ class UtilParallelTest extends TestCase
     {
         $called = 0;
 
-        $loop = new \React\EventLoop\StreamSelectLoop();
-
         $tasks = array(
             function ($callback, $errback) use (&$called) {
                 $callback('foo');
                 $called++;
             },
-            function ($callback, $errback) use ($loop) {
-                $loop->addTimer(0.001, function () use ($errback) {
+            function ($callback, $errback) {
+                Loop::addTimer(0.001, function () use ($errback) {
                     $e = new \RuntimeException('whoops');
                     $errback($e);
                 });
@@ -102,7 +99,7 @@ class UtilParallelTest extends TestCase
 
         Util::parallel($tasks, $callback, $errback);
 
-        $loop->run();
+        Loop::run();
 
         $this->assertSame(2, $called);
     }

--- a/tests/UtilSeriesTest.php
+++ b/tests/UtilSeriesTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Async;
 
 use React\Async\Util;
+use React\EventLoop\Loop;
 
 class UtilSeriesTest extends TestCase
 {
@@ -18,16 +19,14 @@ class UtilSeriesTest extends TestCase
 
     public function testSeriesWithTasks()
     {
-        $loop = new \React\EventLoop\StreamSelectLoop();
-
         $tasks = array(
-            function ($callback, $errback) use ($loop) {
-                $loop->addTimer(0.05, function () use ($callback) {
+            function ($callback, $errback) {
+                Loop::addTimer(0.05, function () use ($callback) {
                     $callback('foo');
                 });
             },
-            function ($callback, $errback) use ($loop) {
-                $loop->addTimer(0.05, function () use ($callback) {
+            function ($callback, $errback) {
+                Loop::addTimer(0.05, function () use ($callback) {
                     $callback('bar');
                 });
             },
@@ -41,7 +40,7 @@ class UtilSeriesTest extends TestCase
         $timer = new Timer($this);
         $timer->start();
 
-        $loop->run();
+        Loop::run();
 
         $timer->stop();
         $timer->assertInRange(0.10, 0.20);

--- a/tests/UtilWaterfallTest.php
+++ b/tests/UtilWaterfallTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Async;
 
 use React\Async\Util;
+use React\EventLoop\Loop;
 
 class UtilWaterfallTest extends TestCase
 {
@@ -18,21 +19,19 @@ class UtilWaterfallTest extends TestCase
 
     public function testWaterfallWithTasks()
     {
-        $loop = new \React\EventLoop\StreamSelectLoop();
-
         $tasks = array(
-            function ($callback, $errback) use ($loop) {
-                $loop->addTimer(0.05, function () use ($callback) {
+            function ($callback, $errback) {
+                Loop::addTimer(0.05, function () use ($callback) {
                     $callback('foo');
                 });
             },
-            function ($foo, $callback, $errback) use ($loop) {
-                $loop->addTimer(0.05, function () use ($callback, $foo) {
+            function ($foo, $callback, $errback) {
+                Loop::addTimer(0.05, function () use ($callback, $foo) {
                     $callback($foo.'bar');
                 });
             },
-            function ($bar, $callback, $errback) use ($loop) {
-                $loop->addTimer(0.05, function () use ($callback, $bar) {
+            function ($bar, $callback, $errback) {
+                Loop::addTimer(0.05, function () use ($callback, $bar) {
                     $callback($bar.'baz');
                 });
             },
@@ -46,7 +45,7 @@ class UtilWaterfallTest extends TestCase
         $timer = new Timer($this);
         $timer->start();
 
-        $loop->run();
+        Loop::run();
 
         $timer->stop();
         $timer->assertInRange(0.15, 0.30);


### PR DESCRIPTION
The raising of the dead part 3.

This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop) (and also applying the first EventLoop update since ~9 years).

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229 and https://github.com/reactphp/event-loop/pull/232
Also builds on top of #2 and #3