### PR TITLE
Use Promise-based APIs instead of callbacks (continuation-passing style)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "react/promise": "^2.8 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",


### PR DESCRIPTION
The raising of the dead part 6/6! 🎉

This changeset updates the code base to use Promise-based APIs instead of callbacks (continuation-passing style).

```php
// old
React\Async\parallel($tasks, $callback, $errback);
React\Async\series($tasks, $callback, $errback);
React\Async\waterfall($tasks, $callback, $errback);

// new
React\Async\parallel($tasks)->then($callback, $errback);
React\Async\series($tasks)->then($callback, $errback);
React\Async\waterfall($tasks)->then($callback, $errback);
```

Builds on top of #2, #3, #4, #5 and #6