### PR TITLE
Add new `await()` function (import from clue/reactphp-block)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Async\await(…);
 
 ### await()
 
-The `await(PromiseInterface $promise, ?LoopInterface $loop = null): mixed` function can be used to
+The `await(PromiseInterface $promise): mixed` function can be used to
 block waiting for the given `$promise` to be fulfilled.
 
 ```php
@@ -62,8 +62,14 @@ $result = React\Async\await($promise);
 ```
 
 This function will only return after the given `$promise` has settled, i.e.
-either fulfilled or rejected. In the meantime, the event loop will run any
-events attached to the same loop until the promise settles.
+either fulfilled or rejected.
+
+While the promise is pending, this function will assume control over the event
+loop. Internally, it will `run()` the [default loop](https://github.com/reactphp/event-loop#loop)
+until the promise settles and then calls `stop()` to terminate execution of the
+loop. This means this function is more suited for short-lived promise executions
+when using promise-based APIs is not feasible. For long-running applications,
+using promise-based APIs by leveraging chained `then()` calls is usually preferable.
 
 Once the promise is fulfilled, this function will return whatever the promise
 resolved to.
@@ -82,19 +88,6 @@ try {
     echo 'ERROR: ' . $exception->getMessage();
 }
 ```
-
-This function takes an optional `LoopInterface|null $loop` parameter that can be used to
-pass the event loop instance to use. You can use a `null` value here in order to
-use the [default loop](https://github.com/reactphp/event-loop#loop). This value
-SHOULD NOT be given unless you're sure you want to explicitly use a given event
-loop instance.
-
-Note that this function will assume control over the event loop. Internally, it
-will actually `run()` the loop until the promise settles and then calls `stop()` to
-terminate execution of the loop. This means this function is more suited for
-short-lived promise executions when using promise-based APIs is not feasible.
-For long-running applications, using promise-based APIs by leveraging chained
-`then()` calls is usually preferable.
 
 ### parallel()
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Async\await(…);
 
 ### await()
 
-The `await(PromiseInterface $promise, ?LoopInterface $loop = null, ?float $timeout = null): mixed` function can be used to
+The `await(PromiseInterface $promise, ?LoopInterface $loop = null): mixed` function can be used to
 block waiting for the given `$promise` to be fulfilled.
 
 ```php
@@ -88,17 +88,6 @@ pass the event loop instance to use. You can use a `null` value here in order to
 use the [default loop](https://github.com/reactphp/event-loop#loop). This value
 SHOULD NOT be given unless you're sure you want to explicitly use a given event
 loop instance.
-
-If no `$timeout` argument is given and the promise stays pending, then this
-will potentially wait/block forever until the promise is settled. To avoid
-this, API authors creating promises are expected to provide means to
-configure a timeout for the promise instead. For more details, see also the
-[`timeout()` function](https://github.com/reactphp/promise-timer#timeout).
-
-If the deprecated `$timeout` argument is given and the promise is still pending once the
-timeout triggers, this will `cancel()` the promise and throw a `TimeoutException`.
-This implies that if you pass a really small (or negative) value, it will still
-start a timer and will thus trigger at the earliest possible time in the future.
 
 Note that this function will assume control over the event loop. Internally, it
 will actually `run()` the loop until the promise settles and then calls `stop()` to

--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ Once the promise is fulfilled, this function will return whatever the promise
 resolved to.
 
 Once the promise is rejected, this will throw whatever the promise rejected
-with. If the promise did not reject with an `Exception`, then this function
-will throw an `UnexpectedValueException` instead.
+with. If the promise did not reject with an `Exception` or `Throwable` (PHP 7+),
+then this function will throw an `UnexpectedValueException` instead.
 
 ```php
 try {
     $result = React\Async\await($promise);
     // promise successfully fulfilled with $result
     echo 'Result: ' . $result;
-} catch (Exception $exception) {
-    // promise rejected with $exception
-    echo 'ERROR: ' . $exception->getMessage();
+} catch (Throwable $e) {
+    // promise rejected with $e
+    echo 'Error: ' . $e->getMessage();
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "react/promise": "^2.8 || ^1.2.1"
+        "react/event-loop": "^1.2",
+        "react/promise": "^2.8 || ^1.2.1",
+        "react/promise-timer": "^1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
-        "react/event-loop": "^1.2"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "suggest": {
         "react/event-loop": "You need an event loop for this to make sense."

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "require": {
         "php": ">=5.3.2",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.8 || ^1.2.1",
-        "react/promise-timer": "^1.5"
+        "react/promise": "^2.8 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,8 +2,124 @@
 
 namespace React\Async;
 
+use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
+use React\Promise\Timer;
+
+/**
+ * Block waiting for the given `$promise` to be fulfilled.
+ *
+ * ```php
+ * $result = React\Async\await($promise, $loop);
+ * ```
+ *
+ * This function will only return after the given `$promise` has settled, i.e.
+ * either fulfilled or rejected. In the meantime, the event loop will run any
+ * events attached to the same loop until the promise settles.
+ *
+ * Once the promise is fulfilled, this function will return whatever the promise
+ * resolved to.
+ *
+ * Once the promise is rejected, this will throw whatever the promise rejected
+ * with. If the promise did not reject with an `Exception`, then this function
+ * will throw an `UnexpectedValueException` instead.
+ *
+ * ```php
+ * try {
+ *     $result = React\Async\await($promise, $loop);
+ *     // promise successfully fulfilled with $result
+ *     echo 'Result: ' . $result;
+ * } catch (Exception $exception) {
+ *     // promise rejected with $exception
+ *     echo 'ERROR: ' . $exception->getMessage();
+ * }
+ * ```
+ *
+ * This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use. You can use a `null` value here in order to
+ * use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+ * SHOULD NOT be given unless you're sure you want to explicitly use a given event
+ * loop instance.
+ *
+ * If no `$timeout` argument is given and the promise stays pending, then this
+ * will potentially wait/block forever until the promise is settled. To avoid
+ * this, API authors creating promises are expected to provide means to
+ * configure a timeout for the promise instead. For more details, see also the
+ * [`timeout()` function](https://github.com/reactphp/promise-timer#timeout).
+ *
+ * If the deprecated `$timeout` argument is given and the promise is still pending once the
+ * timeout triggers, this will `cancel()` the promise and throw a `TimeoutException`.
+ * This implies that if you pass a really small (or negative) value, it will still
+ * start a timer and will thus trigger at the earliest possible time in the future.
+ *
+ * Note that this function will assume control over the event loop. Internally, it
+ * will actually `run()` the loop until the promise settles and then calls `stop()` to
+ * terminate execution of the loop. This means this function is more suited for
+ * short-lived promise executions when using promise-based APIs is not feasible.
+ * For long-running applications, using promise-based APIs by leveraging chained
+ * `then()` calls is usually preferable.
+ *
+ * @param PromiseInterface $promise
+ * @param ?LoopInterface   $loop
+ * @param ?float           $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
+ * @return mixed returns whatever the promise resolves to
+ * @throws \Exception when the promise is rejected
+ * @throws \React\Promise\Timer\TimeoutException if the $timeout is given and triggers
+ */
+function await(PromiseInterface $promise, LoopInterface $loop = null, $timeout = null)
+{
+    $wait = true;
+    $resolved = null;
+    $exception = null;
+    $rejected = false;
+    $loop = $loop ?: Loop::get();
+
+    if ($timeout !== null) {
+        $promise = Timer\timeout($promise, $timeout, $loop);
+    }
+
+    $promise->then(
+        function ($c) use (&$resolved, &$wait, $loop) {
+            $resolved = $c;
+            $wait = false;
+            $loop->stop();
+        },
+        function ($error) use (&$exception, &$rejected, &$wait, $loop) {
+            $exception = $error;
+            $rejected = true;
+            $wait = false;
+            $loop->stop();
+        }
+    );
+
+    // Explicitly overwrite argument with null value. This ensure that this
+    // argument does not show up in the stack trace in PHP 7+ only.
+    $promise = null;
+
+    while ($wait) {
+        $loop->run();
+    }
+
+    if ($rejected) {
+        if (!$exception instanceof \Exception && !$exception instanceof \Throwable) {
+            $exception = new \UnexpectedValueException(
+                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception))
+            );
+        } elseif (!$exception instanceof \Exception) {
+            $exception = new \UnexpectedValueException(
+                'Promise rejected with unexpected ' . get_class($exception) . ': ' . $exception->getMessage(),
+                $exception->getCode(),
+                $exception
+            );
+        }
+
+        throw $exception;
+    }
+
+    return $resolved;
+}
 
 /**
  * @param array<callable():PromiseInterface<mixed,Exception>> $tasks

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,7 +6,6 @@ use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
-use React\Promise\Timer;
 
 /**
  * Block waiting for the given `$promise` to be fulfilled.
@@ -43,17 +42,6 @@ use React\Promise\Timer;
  * SHOULD NOT be given unless you're sure you want to explicitly use a given event
  * loop instance.
  *
- * If no `$timeout` argument is given and the promise stays pending, then this
- * will potentially wait/block forever until the promise is settled. To avoid
- * this, API authors creating promises are expected to provide means to
- * configure a timeout for the promise instead. For more details, see also the
- * [`timeout()` function](https://github.com/reactphp/promise-timer#timeout).
- *
- * If the deprecated `$timeout` argument is given and the promise is still pending once the
- * timeout triggers, this will `cancel()` the promise and throw a `TimeoutException`.
- * This implies that if you pass a really small (or negative) value, it will still
- * start a timer and will thus trigger at the earliest possible time in the future.
- *
  * Note that this function will assume control over the event loop. Internally, it
  * will actually `run()` the loop until the promise settles and then calls `stop()` to
  * terminate execution of the loop. This means this function is more suited for
@@ -63,22 +51,16 @@ use React\Promise\Timer;
  *
  * @param PromiseInterface $promise
  * @param ?LoopInterface   $loop
- * @param ?float           $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
  * @return mixed returns whatever the promise resolves to
  * @throws \Exception when the promise is rejected
- * @throws \React\Promise\Timer\TimeoutException if the $timeout is given and triggers
  */
-function await(PromiseInterface $promise, LoopInterface $loop = null, $timeout = null)
+function await(PromiseInterface $promise, LoopInterface $loop = null)
 {
     $wait = true;
     $resolved = null;
     $exception = null;
     $rejected = false;
     $loop = $loop ?: Loop::get();
-
-    if ($timeout !== null) {
-        $promise = Timer\timeout($promise, $timeout, $loop);
-    }
 
     $promise->then(
         function ($c) use (&$resolved, &$wait, $loop) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -27,23 +27,25 @@ use React\Promise\PromiseInterface;
  * resolved to.
  *
  * Once the promise is rejected, this will throw whatever the promise rejected
- * with. If the promise did not reject with an `Exception`, then this function
- * will throw an `UnexpectedValueException` instead.
+ * with. If the promise did not reject with an `Exception` or `Throwable` (PHP 7+),
+ * then this function will throw an `UnexpectedValueException` instead.
  *
  * ```php
  * try {
  *     $result = React\Async\await($promise, $loop);
  *     // promise successfully fulfilled with $result
  *     echo 'Result: ' . $result;
- * } catch (Exception $exception) {
- *     // promise rejected with $exception
- *     echo 'ERROR: ' . $exception->getMessage();
+ * } catch (Throwable $e) {
+ *     // promise rejected with $e
+ *     echo 'Error: ' . $e->getMessage();
  * }
  * ```
  *
  * @param PromiseInterface $promise
  * @return mixed returns whatever the promise resolves to
- * @throws \Exception when the promise is rejected
+ * @throws \Exception when the promise is rejected with an `Exception`
+ * @throws \Throwable when the promise is rejected with a `Throwable` (PHP 7+)
+ * @throws \UnexpectedValueException when the promise is rejected with an unexpected value (Promise API v1 or v2 only)
  */
 function await(PromiseInterface $promise)
 {
@@ -75,15 +77,10 @@ function await(PromiseInterface $promise)
     }
 
     if ($rejected) {
+        // promise is rejected with an unexpected value (Promise API v1 or v2 only)
         if (!$exception instanceof \Exception && !$exception instanceof \Throwable) {
             $exception = new \UnexpectedValueException(
                 'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception))
-            );
-        } elseif (!$exception instanceof \Exception) {
-            $exception = new \UnexpectedValueException(
-                'Promise rejected with unexpected ' . get_class($exception) . ': ' . $exception->getMessage(),
-                $exception->getCode(),
-                $exception
             );
         }
 

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace React\Tests\Async;
+
+use React;
+use React\EventLoop\Loop;
+use React\Promise;
+use React\Promise\Deferred;
+use React\Promise\Timer\TimeoutException;
+
+class AwaitTest extends TestCase
+{
+    protected $loop;
+
+    /**
+     * @before
+     */
+    public function setUpLoop()
+    {
+        $this->loop = Loop::get();
+    }
+
+    public function testAwaitOneRejected()
+    {
+        $promise = $this->createPromiseRejected(new \Exception('test'));
+
+        $this->setExpectedException('Exception', 'test');
+        React\Async\await($promise, $this->loop);
+    }
+
+    public function testAwaitOneRejectedWithFalseWillWrapInUnexpectedValueException()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
+            $this->markTestSkipped('Promises must be rejected with a \Throwable instance since Promise v3');
+        }
+
+        $promise = Promise\reject(false);
+
+        $this->setExpectedException('UnexpectedValueException', 'Promise rejected with unexpected value of type bool');
+        React\Async\await($promise, $this->loop);
+    }
+
+    public function testAwaitOneRejectedWithNullWillWrapInUnexpectedValueException()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
+            $this->markTestSkipped('Promises must be rejected with a \Throwable instance since Promise v3');
+        }
+
+        $promise = Promise\reject(null);
+
+        $this->setExpectedException('UnexpectedValueException', 'Promise rejected with unexpected value of type NULL');
+        React\Async\await($promise, $this->loop);
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testAwaitOneRejectedWithPhp7ErrorWillWrapInUnexpectedValueExceptionWithPrevious()
+    {
+        $promise = Promise\reject(new \Error('Test', 42));
+
+        try {
+            React\Async\await($promise, $this->loop);
+            $this->fail();
+        } catch (\UnexpectedValueException $e) {
+            $this->assertEquals('Promise rejected with unexpected Error: Test', $e->getMessage());
+            $this->assertEquals(42, $e->getCode());
+            $this->assertInstanceOf('Throwable', $e->getPrevious());
+            $this->assertEquals('Test', $e->getPrevious()->getMessage());
+            $this->assertEquals(42, $e->getPrevious()->getCode());
+        }
+    }
+
+    public function testAwaitOneResolved()
+    {
+        $promise = $this->createPromiseResolved(2);
+
+        $this->assertEquals(2, React\Async\await($promise, $this->loop));
+    }
+
+    public function testAwaitReturnsFulfilledValueWithoutGivingLoop()
+    {
+        $promise = Promise\resolve(42);
+
+        $this->assertEquals(42, React\Async\await($promise));
+    }
+
+    public function testAwaitOneInterrupted()
+    {
+        $promise = $this->createPromiseResolved(2, 0.02);
+        $this->createTimerInterrupt(0.01);
+
+        $this->assertEquals(2, React\Async\await($promise, $this->loop));
+    }
+
+    public function testAwaitOncePendingWillThrowOnTimeout()
+    {
+        $promise = new Promise\Promise(function () { });
+
+        $this->setExpectedException('React\Promise\Timer\TimeoutException');
+        React\Async\await($promise, $this->loop, 0.001);
+    }
+
+    public function testAwaitOncePendingWillThrowAndCallCancellerOnTimeout()
+    {
+        $cancelled = false;
+        $promise = new Promise\Promise(function () { }, function () use (&$cancelled) {
+            $cancelled = true;
+        });
+
+        try {
+            React\Async\await($promise, $this->loop, 0.001);
+        } catch (TimeoutException $expected) {
+            $this->assertTrue($cancelled);
+        }
+    }
+
+    public function testAwaitOnceWithTimeoutWillResolvemmediatelyAndCleanUpTimeout()
+    {
+        $promise = Promise\resolve(true);
+
+        $time = microtime(true);
+        React\Async\await($promise, $this->loop, 5.0);
+        $this->loop->run();
+        $time = microtime(true) - $time;
+
+        $this->assertLessThan(0.1, $time);
+    }
+
+    public function testAwaitOneResolvesShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When') && PHP_VERSION_ID >= 50400) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API with PHP 5.4+');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Promise\resolve(1);
+        React\Async\await($promise, $this->loop);
+        unset($promise);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testAwaitOneRejectedShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When') && PHP_VERSION_ID >= 50400) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API with PHP 5.4+');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Promise\reject(new \RuntimeException());
+        try {
+            React\Async\await($promise, $this->loop);
+        } catch (\Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testAwaitOneRejectedWithTimeoutShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When') && PHP_VERSION_ID >= 50400) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API with PHP 5.4+');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Promise\reject(new \RuntimeException());
+        try {
+            React\Async\await($promise, $this->loop, 0.001);
+        } catch (\Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    public function testAwaitNullValueShouldNotCreateAnyGarbageReferences()
+    {
+        if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
+            $this->markTestSkipped('Promises must be rejected with a \Throwable instance since Promise v3');
+        }
+
+        if (class_exists('React\Promise\When') && PHP_VERSION_ID >= 50400) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API with PHP 5.4+');
+        }
+
+        gc_collect_cycles();
+
+        $promise = Promise\reject(null);
+        try {
+            React\Async\await($promise, $this->loop);
+        } catch (\Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testAwaitPendingPromiseWithTimeoutAndCancellerShouldNotCreateAnyGarbageReferences()
+    {
+        if (class_exists('React\Promise\When')) {
+            $this->markTestSkipped('Not supported on legacy Promise v1 API');
+        }
+
+        gc_collect_cycles();
+
+        $promise = new \React\Promise\Promise(function () { }, function () {
+            throw new \RuntimeException();
+        });
+        try {
+            React\Async\await($promise, $this->loop, 0.001);
+        } catch (\Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testAwaitPendingPromiseWithTimeoutAndWithoutCancellerShouldNotCreateAnyGarbageReferences()
+    {
+        gc_collect_cycles();
+
+        $promise = new \React\Promise\Promise(function () { });
+        try {
+            React\Async\await($promise, $this->loop, 0.001);
+        } catch (\Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testAwaitPendingPromiseWithTimeoutAndNoOpCancellerShouldNotCreateAnyGarbageReferences()
+    {
+        gc_collect_cycles();
+
+        $promise = new \React\Promise\Promise(function () { }, function () {
+            // no-op
+        });
+        try {
+            React\Async\await($promise, $this->loop, 0.001);
+        } catch (\Exception $e) {
+            // no-op
+        }
+        unset($promise, $e);
+
+        $this->assertEquals(0, gc_collect_cycles());
+    }
+
+    protected function createPromiseResolved($value = null, $delay = 0.01)
+    {
+        $deferred = new Deferred();
+
+        $this->loop->addTimer($delay, function () use ($deferred, $value) {
+            $deferred->resolve($value);
+        });
+
+        return $deferred->promise();
+    }
+
+    protected function createPromiseRejected($value = null, $delay = 0.01)
+    {
+        $deferred = new Deferred();
+
+        $this->loop->addTimer($delay, function () use ($deferred, $value) {
+            $deferred->reject($value);
+        });
+
+        return $deferred->promise();
+    }
+
+    protected function createTimerInterrupt($delay = 0.01)
+    {
+        $loop = $this->loop;
+        $loop->addTimer($delay, function () use ($loop) {
+            $loop->stop();
+        });
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+}

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -44,20 +44,12 @@ class AwaitTest extends TestCase
     /**
      * @requires PHP 7
      */
-    public function testAwaitOneRejectedWithPhp7ErrorWillWrapInUnexpectedValueExceptionWithPrevious()
+    public function testAwaitRejectedWithPhp7ErrorWillThrowOriginalError()
     {
         $promise = Promise\reject(new \Error('Test', 42));
 
-        try {
-            React\Async\await($promise);
-            $this->fail();
-        } catch (\UnexpectedValueException $e) {
-            $this->assertEquals('Promise rejected with unexpected Error: Test', $e->getMessage());
-            $this->assertEquals(42, $e->getCode());
-            $this->assertInstanceOf('Throwable', $e->getPrevious());
-            $this->assertEquals('Test', $e->getPrevious()->getMessage());
-            $this->assertEquals(42, $e->getPrevious()->getCode());
-        }
+        $this->setExpectedException('Error', 'Test', 42);
+        React\Async\await($promise);
     }
 
     public function testAwaitOneResolved()


### PR DESCRIPTION
This changeset adds a new `await()` function (imported from [clue/reactphp-block](https://github.com/clue/reactphp-block) v1.5.0):

```php
try {
    $result = React\Async\await($promise);
    // promise successfully fulfilled with $result
    echo 'Result: ' . $result;
} catch (Throwable $e) {
    // promise rejected with $e
    echo 'Error: ' . $e->getMessage();
}
```

Most notably, this function makes it much easier to integrate async code in blocking code bases, such as test suites. On top of this, I hear there's also something new in the pipeline already to make this more useful also for long-running applications 🤫

Note that this function will assume control over the event loop. Internally, it will actually `run()` the loop until the promise settles and then calls `stop()` toterminate execution of the loop. This means this function is more suited for short-lived promise executions when using promise-based APIs is not feasible. For long-running applications, using promise-based APIs by leveraging chained `then()` calls is usually preferable. 

Builds on top of https://github.com/clue/reactphp-block/pull/57, https://github.com/clue/reactphp-block/pull/59, https://github.com/clue/reactphp-block/pull/60 and others
Also builds on top of #7 and #4