### PR TITLE
Support promise cancellation

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -102,7 +102,7 @@ function parallel(array $tasks)
 
     $done = function () use (&$results, &$errors, $deferred) {
         if (count($errors)) {
-            $deferred->reject(array_shift($errors));
+            $deferred->reject(reset($errors));
             return;
         }
 
@@ -116,7 +116,7 @@ function parallel(array $tasks)
     }
 
     $checkDone = function () use (&$results, &$errors, $numTasks, $done) {
-        if ($numTasks === count($results) + count($errors)) {
+        if ($numTasks === count($results) || count($errors)) {
             $done();
         }
     };
@@ -136,6 +136,10 @@ function parallel(array $tasks)
         assert($promise instanceof PromiseInterface);
 
         $promise->then($taskCallback, $taskErrback);
+
+        if ($errors) {
+            break;
+        }
     }
 
     return $deferred->promise();

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -29,7 +29,7 @@ class ParallelTest extends TestCase
             },
             function () {
                 return new Promise(function ($resolve) {
-                    Loop::addTimer(0.1, function () use ($resolve) {
+                    Loop::addTimer(0.11, function () use ($resolve) {
                         $resolve('bar');
                     });
                 });
@@ -49,7 +49,7 @@ class ParallelTest extends TestCase
         $timer->assertInRange(0.1, 0.2);
     }
 
-    public function testParallelWithError()
+    public function testParallelWithErrorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
     {
         $called = 0;
 
@@ -60,7 +60,8 @@ class ParallelTest extends TestCase
                     $resolve('foo');
                 });
             },
-            function () {
+            function () use (&$called) {
+                $called++;
                 return new Promise(function () {
                     throw new \RuntimeException('whoops');
                 });
@@ -80,7 +81,7 @@ class ParallelTest extends TestCase
         $this->assertSame(2, $called);
     }
 
-    public function testParallelWithDelayedError()
+    public function testParallelWithDelayedErrorReturnsPromiseRejectedWithExceptionFromTask()
     {
         $called = 0;
 
@@ -91,7 +92,8 @@ class ParallelTest extends TestCase
                     $resolve('foo');
                 });
             },
-            function () {
+            function () use (&$called) {
+                $called++;
                 return new Promise(function ($_, $reject) {
                     Loop::addTimer(0.001, function () use ($reject) {
                         $reject(new \RuntimeException('whoops'));
@@ -112,6 +114,6 @@ class ParallelTest extends TestCase
 
         Loop::run();
 
-        $this->assertSame(2, $called);
+        $this->assertSame(3, $called);
     }
 }

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -110,6 +110,29 @@ class ParallelTest extends TestCase
         $this->assertSame(1, $cancelled);
     }
 
+    public function testParallelWillCancelPendingPromisesWhenCallingCancelOnResultingPromise()
+    {
+        $cancelled = 0;
+
+        $tasks = array(
+            function () use (&$cancelled) {
+                return new Promise(function () { }, function () use (&$cancelled) {
+                    $cancelled++;
+                });
+            },
+            function () use (&$cancelled) {
+                return new Promise(function () { }, function () use (&$cancelled) {
+                    $cancelled++;
+                });
+            }
+        );
+
+        $promise = React\Async\parallel($tasks);
+        $promise->cancel();
+
+        $this->assertSame(2, $cancelled);
+    }
+
     public function testParallelWithDelayedErrorReturnsPromiseRejectedWithExceptionFromTask()
     {
         $called = 0;

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -79,4 +79,27 @@ class SeriesTest extends TestCase
 
         $this->assertSame(1, $called);
     }
+
+    public function testSeriesWillCancelFirstPendingPromiseWhenCallingCancelOnResultingPromise()
+    {
+        $cancelled = 0;
+
+        $tasks = array(
+            function () {
+                return new Promise(function ($resolve) {
+                    $resolve();
+                });
+            },
+            function () use (&$cancelled) {
+                return new Promise(function () { }, function () use (&$cancelled) {
+                    $cancelled++;
+                });
+            }
+        );
+
+        $promise = React\Async\series($tasks);
+        $promise->cancel();
+
+        $this->assertSame(1, $cancelled);
+    }
 }

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -86,4 +86,27 @@ class WaterfallTest extends TestCase
 
         $this->assertSame(1, $called);
     }
+
+    public function testWaterfallWillCancelFirstPendingPromiseWhenCallingCancelOnResultingPromise()
+    {
+        $cancelled = 0;
+
+        $tasks = array(
+            function () {
+                return new Promise(function ($resolve) {
+                    $resolve();
+                });
+            },
+            function () use (&$cancelled) {
+                return new Promise(function () { }, function () use (&$cancelled) {
+                    $cancelled++;
+                });
+            }
+        );
+
+        $promise = React\Async\waterfall($tasks);
+        $promise->cancel();
+
+        $this->assertSame(1, $cancelled);
+    }
 }


### PR DESCRIPTION
This changeset adds support for promise cancellation. Once a task fails, it will no longer start any additional tasks and will cancel all pending tasks. Additionally, you can call `cancel()` on the resulting promise to cancel all pending tasks.

Builds on top of #7