### PR TITLE
Support promise cancellation for `coroutine()` and clean up garbage references

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -226,10 +226,12 @@ function coroutine(callable $function, ...$args): PromiseInterface
 
     $promise = null;
     $deferred = new Deferred(function () use (&$promise) {
-        if ($promise instanceof CancellablePromiseInterface) {
-            $promise->cancel();
+        // cancel pending promise(s) as long as generator function keeps yielding
+        while ($promise instanceof CancellablePromiseInterface) {
+            $temp = $promise;
+            $promise = null;
+            $temp->cancel();
         }
-        $promise = null;
     });
 
     /** @var callable $next */

--- a/src/functions.php
+++ b/src/functions.php
@@ -224,10 +224,16 @@ function coroutine(callable $function, ...$args): PromiseInterface
         return resolve($generator);
     }
 
-    $deferred = new Deferred();
+    $promise = null;
+    $deferred = new Deferred(function () use (&$promise) {
+        if ($promise instanceof CancellablePromiseInterface) {
+            $promise->cancel();
+        }
+        $promise = null;
+    });
 
     /** @var callable $next */
-    $next = function () use ($deferred, $generator, &$next) {
+    $next = function () use ($deferred, $generator, &$next, &$promise) {
         try {
             if (!$generator->valid()) {
                 $deferred->resolve($generator->getReturn());

--- a/src/functions.php
+++ b/src/functions.php
@@ -238,16 +238,19 @@ function coroutine(callable $function, ...$args): PromiseInterface
     $next = function () use ($deferred, $generator, &$next, &$promise) {
         try {
             if (!$generator->valid()) {
+                $next = null;
                 $deferred->resolve($generator->getReturn());
                 return;
             }
         } catch (\Throwable $e) {
+            $next = null;
             $deferred->reject($e);
             return;
         }
 
         $promise = $generator->current();
         if (!$promise instanceof PromiseInterface) {
+            $next = null;
             $deferred->reject(new \UnexpectedValueException(
                 'Expected coroutine to yield ' . PromiseInterface::class . ', but got ' . (is_object($promise) ? get_class($promise) : gettype($promise))
             ));
@@ -260,7 +263,8 @@ function coroutine(callable $function, ...$args): PromiseInterface
         }, function (\Throwable $reason) use ($generator, $next) {
             $generator->throw($reason);
             $next();
-        })->then(null, function (\Throwable $reason) use ($deferred) {
+        })->then(null, function (\Throwable $reason) use ($deferred, &$next) {
+            $next = null;
             $deferred->reject($reason);
         });
     };

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Async;
 
+use React\Promise\Promise;
 use function React\Async\coroutine;
 use function React\Promise\reject;
 use function React\Promise\resolve;
@@ -103,5 +104,18 @@ class CoroutineTest extends TestCase
         });
 
         $promise->then(null, $this->expectCallableOnceWith(new \UnexpectedValueException('Expected coroutine to yield React\Promise\PromiseInterface, but got integer')));
+    }
+
+    public function testCoroutineWillCancelPendingPromiseWhenCallingCancelOnResultingPromise()
+    {
+        $promise = coroutine(function () {
+            yield new Promise(function () { }, function () {
+                throw new \RuntimeException('Operation cancelled', 42);
+            });
+        });
+
+        $promise->cancel();
+
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Operation cancelled', 42)));
     }
 }


### PR DESCRIPTION
This changeset adds support for promise cancellation for the new `coroutine()` function. You can now call `cancel()` on the resulting promise to cancel all pending promises within the coroutine. On top this, we now make sure to clean up any garbage references to not leak any memory.

Builds on top of #9 and #12
Refs https://github.com/reactphp/socket/pull/170 and others