### PR TITLE
Add Fiber-based `async` and `await` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,8 @@ $result = React\Async\await($promise);
 ```
 
 This function will only return after the given `$promise` has settled, i.e.
-either fulfilled or rejected.
-
-While the promise is pending, this function will assume control over the event
-loop. Internally, it will `run()` the [default loop](https://github.com/reactphp/event-loop#loop)
-until the promise settles and then calls `stop()` to terminate execution of the
-loop. This means this function is more suited for short-lived promise executions
-when using promise-based APIs is not feasible. For long-running applications,
-using promise-based APIs by leveraging chained `then()` calls is usually preferable.
+either fulfilled or rejected. While the promise is pending, this function will 
+suspend the fiber it's called from until the promise is settled.
 
 Once the promise is fulfilled, this function will return whatever the promise
 resolved to.

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "phpunit/phpunit": "^9.3"
     },
     "autoload": {
+        "psr-4": {
+            "React\\Async\\": "src/"
+        },
         "files": [
             "src/functions_include.php"
         ]

--- a/src/FiberFactory.php
+++ b/src/FiberFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace React\Async;
+
+/**
+ * This factory its only purpose is interoperability. Where with
+ * event loops one could simply wrap another event loop. But with fibers
+ * that has become impossible and as such we provide this factory and the
+ * FiberInterface.
+ *
+ * Usage is not documented and as such not supported and might chang without
+ * notice. Use at your own risk.
+ *
+ * @internal
+ */
+final class FiberFactory
+{
+    private static ?\Closure $factory = null;
+
+    public static function create(): FiberInterface
+    {
+        return (self::factory())();
+    }
+
+    public static function factory(\Closure $factory = null): \Closure
+    {
+        if ($factory !== null) {
+            self::$factory = $factory;
+        }
+
+        return self::$factory ?? static fn (): FiberInterface => new SimpleFiber();
+    }
+}

--- a/src/FiberInterface.php
+++ b/src/FiberInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace React\Async;
+
+/**
+ * This interface its only purpose is interoperability. Where with
+ * event loops one could simply wrap another event loop. But with fibers
+ * that has become impossible and as such we provide this interface and the
+ * FiberFactory.
+ *
+ * Usage is not documented and as such not supported and might chang without
+ * notice. Use at your own risk.
+ *
+ * @internal
+ */
+interface FiberInterface
+{
+    public function resume(mixed $value): void;
+
+    public function throw(mixed $throwable): void;
+
+    public function suspend(): mixed;
+}

--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace React\Async;
+
+use React\EventLoop\Loop;
+
+/**
+ * @internal
+ */
+final class SimpleFiber
+{
+    private static ?\Fiber $scheduler = null;
+    private ?\Fiber $fiber = null;
+
+    public function __construct()
+    {
+        $this->fiber = \Fiber::getCurrent();
+    }
+
+    public function resume(mixed $value): void
+    {
+        if ($this->fiber === null) {
+            Loop::futureTick(static fn() => \Fiber::suspend(static fn() => $value));
+            return;
+        }
+
+        Loop::futureTick(fn() => $this->fiber->resume($value));
+    }
+
+    public function throw(mixed $throwable): void
+    {
+        if (!$throwable instanceof \Throwable) {
+            $throwable = new \UnexpectedValueException(
+                'Promise rejected with unexpected value of type ' . (is_object($throwable) ? get_class($throwable) : gettype($throwable))
+            );
+        }
+
+        if ($this->fiber === null) {
+            Loop::futureTick(static fn() => \Fiber::suspend(static fn() => throw $throwable));
+            return;
+        }
+
+        Loop::futureTick(fn() => $this->fiber->throw($throwable));
+    }
+
+    public function suspend(): mixed
+    {
+        if ($this->fiber === null) {
+            if (self::$scheduler === null || self::$scheduler->isTerminated()) {
+                self::$scheduler = new \Fiber(static fn() => Loop::run());
+                // Run event loop to completion on shutdown.
+                \register_shutdown_function(static function (): void {
+                    if (self::$scheduler->isSuspended()) {
+                        self::$scheduler->resume();
+                    }
+                });
+            }
+
+            return (self::$scheduler->isStarted() ? self::$scheduler->resume() : self::$scheduler->start())();
+        }
+
+        return \Fiber::suspend();
+    }
+}

--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -7,7 +7,7 @@ use React\EventLoop\Loop;
 /**
  * @internal
  */
-final class SimpleFiber
+final class SimpleFiber implements FiberInterface
 {
     private static ?\Fiber $scheduler = null;
     private ?\Fiber $fiber = null;

--- a/src/functions.php
+++ b/src/functions.php
@@ -78,7 +78,7 @@ function async(callable $function, mixed ...$args): PromiseInterface
  */
 function await(PromiseInterface $promise): mixed
 {
-    $fiber = new SimpleFiber();
+    $fiber = FiberFactory::create();
 
     $promise->then(
         function (mixed $value) use (&$resolved, $fiber): void {

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace React\Tests\Async;
+
+use React;
+use React\EventLoop\Loop;
+use React\Promise\Promise;
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\all;
+
+class AsyncTest extends TestCase
+{
+    public function testAsyncReturnsPendingPromise()
+    {
+        $promise = async(function () {
+            return 42;
+        });
+
+        $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    public function testAsyncReturnsPromiseThatFulfillsWithValueWhenCallbackReturns()
+    {
+        $promise = async(function () {
+            return 42;
+        });
+
+        $value = await($promise);
+
+        $this->assertEquals(42, $value);
+    }
+
+    public function testAsyncReturnsPromiseThatRejectsWithExceptionWhenCallbackThrows()
+    {
+        $promise = async(function () {
+            throw new \RuntimeException('Foo', 42);
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Foo');
+        $this->expectExceptionCode(42);
+        await($promise);
+    }
+
+    public function testAsyncReturnsPromiseThatFulfillsWithValueWhenCallbackReturnsAfterAwaitingPromise()
+    {
+        $promise = async(function () {
+            $promise = new Promise(function ($resolve) {
+                Loop::addTimer(0.001, fn () => $resolve(42));
+            });
+
+            return await($promise);
+        });
+
+        $value = await($promise);
+
+        $this->assertEquals(42, $value);
+    }
+
+    public function testAsyncReturnsPromiseThatFulfillsWithValueWhenCallbackReturnsAfterAwaitingTwoConcurrentPromises()
+    {
+        $promise1 = async(function () {
+            $promise = new Promise(function ($resolve) {
+                Loop::addTimer(0.11, fn () => $resolve(21));
+            });
+
+            return await($promise);
+        });
+
+        $promise2 = async(function () {
+            $promise = new Promise(function ($resolve) {
+                Loop::addTimer(0.11, fn () => $resolve(42));
+            });
+
+            return await($promise);
+        });
+
+        $time = microtime(true);
+        $values = await(all([$promise1, $promise2]));
+        $time = microtime(true) - $time;
+
+        $this->assertEquals([21, 42], $values);
+        $this->assertGreaterThan(0.1, $time);
+        $this->assertLessThan(0.12, $time);
+    }
+}

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -70,20 +70,6 @@ class AwaitTest extends TestCase
         $this->assertEquals(42, React\Async\await($promise));
     }
 
-    public function testAwaitReturnsValueWhenPromiseIsFulfilledEvenWhenOtherTimerStopsLoop()
-    {
-        $promise = new Promise(function ($resolve) {
-            Loop::addTimer(0.02, function () use ($resolve) {
-                $resolve(2);
-            });
-        });
-        Loop::addTimer(0.01, function () {
-            Loop::stop();
-        });
-
-        $this->assertEquals(2, React\Async\await($promise));
-    }
-
     public function testAwaitShouldNotCreateAnyGarbageReferencesForResolvedPromise()
     {
         if (class_exists('React\Promise\When')) {


### PR DESCRIPTION
This changeset adds an `await` function which starts a fiber. And also changes the `await` function to use fibers introduced in PHP `8.1` instead of continuously running the event loop until the promise resolves and then stopping the event loop. Accordingly, this is a breaking change that will target the future v4 release. The future v3 and v2 releases are still outstanding and are not affected by this change.

These functions are inspired by @trowski's https://github.com/trowski/react-fiber.

Builds on top of #14 