### PR TITLE
Fast forward resolved/rejected promises with fibers await

### DIFF
--- a/src/FiberInterface.php
+++ b/src/FiberInterface.php
@@ -17,7 +17,7 @@ interface FiberInterface
 {
     public function resume(mixed $value): void;
 
-    public function throw(mixed $throwable): void;
+    public function throw(\Throwable $throwable): void;
 
     public function suspend(): mixed;
 }

--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -27,14 +27,8 @@ final class SimpleFiber implements FiberInterface
         Loop::futureTick(fn() => $this->fiber->resume($value));
     }
 
-    public function throw(mixed $throwable): void
+    public function throw(\Throwable $throwable): void
     {
-        if (!$throwable instanceof \Throwable) {
-            $throwable = new \UnexpectedValueException(
-                'Promise rejected with unexpected value of type ' . (is_object($throwable) ? get_class($throwable) : gettype($throwable))
-            );
-        }
-
         if ($this->fiber === null) {
             Loop::futureTick(static fn() => \Fiber::suspend(static fn() => throw $throwable));
             return;


### PR DESCRIPTION
This makes `await`ing an already resolved promise significantly faster.