### PR TITLE
Make `async` return a callable

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -14,14 +14,13 @@ use function React\Promise\resolve;
  * Execute an async Fiber-based function to "await" promises.
  *
  * @param callable(mixed ...$args):mixed $function
- * @param mixed ...$args Optional list of additional arguments that will be passed to the given `$function` as is
- * @return PromiseInterface<mixed>
+ * @return callable(): PromiseInterface<mixed>
  * @since 4.0.0
  * @see coroutine()
  */
-function async(callable $function, mixed ...$args): PromiseInterface
+function async(callable $function): callable
 {
-    return new Promise(function (callable $resolve, callable $reject) use ($function, $args): void {
+    return static fn (mixed ...$args): PromiseInterface => new Promise(function (callable $resolve, callable $reject) use ($function, $args): void {
         $fiber = new \Fiber(function () use ($resolve, $reject, $function, $args): void {
             try {
                 $resolve($function(...$args));

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -15,7 +15,7 @@ class AsyncTest extends TestCase
     {
         $promise = async(function () {
             return 42;
-        });
+        })();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
@@ -24,7 +24,7 @@ class AsyncTest extends TestCase
     {
         $promise = async(function () {
             return 42;
-        });
+        })();
 
         $value = await($promise);
 
@@ -35,7 +35,7 @@ class AsyncTest extends TestCase
     {
         $promise = async(function () {
             throw new \RuntimeException('Foo', 42);
-        });
+        })();
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Foo');
@@ -51,7 +51,7 @@ class AsyncTest extends TestCase
             });
 
             return await($promise);
-        });
+        })();
 
         $value = await($promise);
 
@@ -66,15 +66,15 @@ class AsyncTest extends TestCase
             });
 
             return await($promise);
-        });
+        })();
 
-        $promise2 = async(function () {
-            $promise = new Promise(function ($resolve) {
-                Loop::addTimer(0.11, fn () => $resolve(42));
+        $promise2 = async(function (int $theAnswerToLifeTheUniverseAndEverything): int {
+            $promise = new Promise(function ($resolve) use ($theAnswerToLifeTheUniverseAndEverything): void {
+                Loop::addTimer(0.11, fn () => $resolve($theAnswerToLifeTheUniverseAndEverything));
             });
 
             return await($promise);
-        });
+        })(42);
 
         $time = microtime(true);
         $values = await(all([$promise1, $promise2]));

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -160,6 +160,6 @@ class AwaitTest extends TestCase
     public function provideAwaiters(): iterable
     {
         yield 'await' => [static fn (React\Promise\PromiseInterface $promise): mixed => React\Async\await($promise)];
-        yield 'async' => [static fn (React\Promise\PromiseInterface $promise): mixed => React\Async\await(React\Async\async(static fn(): mixed => $promise))];
+        yield 'async' => [static fn (React\Promise\PromiseInterface $promise): mixed => React\Async\await(React\Async\async(static fn(): mixed => $promise)())];
     }
 }


### PR DESCRIPTION
By making this change `async()` can now also by used in event loop callbacks such as timers:

```php
Loop::addTimer(0.01, async(function () {
    echo 'Sleeping for one second';
    await(asleep(1));
    echo 'Waking up again';
}));
```

With this change, current `async()` usage changes from:

```php
async(function () {
   //
});
```

To:

```php
async(function () {
   //
})();
```