### PR TITLE
Improve `async()` by making its promises cancellable

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,29 @@ $promise->then(function (int $bytes) {
 });
 ```
 
+Promises returned by `async()` can be cancelled, and when done any currently and future awaited promise inside that and 
+any nested fibers with their awaited promises will also be cancelled. As such the following example will only output 
+`ab` as the [`sleep()`](https://reactphp.org/promise-timer/#sleep) between `a` and `b` is cancelled throwing a timeout 
+exception that bubbles up through the fibers ultimately to the end user through the [`await()`](#await) on the last line 
+of the example.
+
+```php
+$promise = async(static function (): int {
+    echo 'a';
+    await(async(static function(): void {
+        echo 'b';
+        await(sleep(2));
+        echo 'c';
+    })());
+    echo 'd';
+
+    return time();
+})();
+
+$promise->cancel();
+await($promise);
+```
+
 ### await()
 
 The `await(PromiseInterface $promise): mixed` function can be used to

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "react/promise": "^2.8 || ^1.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "react/promise-timer": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/FiberMap.php
+++ b/src/FiberMap.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace React\Async;
+
+use React\Promise\PromiseInterface;
+
+/**
+ * @internal
+ */
+final class FiberMap
+{
+    private static array $status = [];
+    private static array $map   = [];
+
+    public static function register(\Fiber $fiber): void
+    {
+        self::$status[\spl_object_id($fiber)] = false;
+        self::$map[\spl_object_id($fiber)] = [];
+    }
+
+    public static function cancel(\Fiber $fiber): void
+    {
+        self::$status[\spl_object_id($fiber)] = true;
+    }
+
+    public static function isCancelled(\Fiber $fiber): bool
+    {
+        return self::$status[\spl_object_id($fiber)];
+    }
+
+    public static function setPromise(\Fiber $fiber, PromiseInterface $promise): void
+    {
+        self::$map[\spl_object_id($fiber)] = $promise;
+    }
+
+    public static function unsetPromise(\Fiber $fiber, PromiseInterface $promise): void
+    {
+        unset(self::$map[\spl_object_id($fiber)]);
+    }
+
+    public static function has(\Fiber $fiber): bool
+    {
+        return array_key_exists(\spl_object_id($fiber), self::$map);
+    }
+
+    public static function getPromise(\Fiber $fiber): ?PromiseInterface
+    {
+        return self::$map[\spl_object_id($fiber)] ?? null;
+    }
+
+    public static function unregister(\Fiber $fiber): void
+    {
+        unset(self::$status[\spl_object_id($fiber)], self::$map[\spl_object_id($fiber)]);
+    }
+}


### PR DESCRIPTION
Since `async()` returns a promise and those are normally cancelable, implementing this puts them in line with the rest of our ecosystem. As such the following example will throw a timeout exception from the canceled `sleep()` call.

```php
$promise = async(static function (): int {
    echo 'a';
    await(sleep(2));
    echo 'b';

    return time();
})();

$promise->cancel();
await($promise);
````

This builds on top of #15, #18, #19, #26, #28, #30, and #32.