### PR TITLE
Rename `main` branch to `4.x` and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ to have an actual event loop and non-blocking libraries interacting with that
 event loop for it to work. As long as you have a Promise-based API that runs in
 an event loop, it can be used with this library.
 
+> **Development version:** This branch contains the code for the upcoming 4.0
+> release which will be the way forward for this package. However, we will still
+> actively support 3.0 and 2.0 for those not yet on PHP 8.1+.
+>
+> If you're using an older PHP version, you may use the
+> [`3.x` branch](https://github.com/reactphp/async/tree/3.x) (PHP 7.1+) or
+> [`2.x` branch](https://github.com/reactphp/async/tree/2.x) (PHP 5.3+) which both
+> provide a compatible API but do not take advantage of newer language features.
+> See also [installation instructions](#install) for more details.
+
 **Table of Contents**
 
 * [Usage](#usage)
@@ -487,7 +497,7 @@ Once released, this project will follow [SemVer](https://semver.org/).
 At the moment, this will install the latest development version:
 
 ```bash
-$ composer require react/async:dev-main
+$ composer require react/async:^4@dev
 ```
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
@@ -502,7 +512,11 @@ smooth upgrade path. If you're using an older PHP version, you may use the
 [`2.x` branch](https://github.com/reactphp/async/tree/2.x) (PHP 5.3+) which both
 provide a compatible API but do not take advantage of newer language features.
 You may target multiple versions at the same time to support a wider range of
-PHP versions.
+PHP versions like this:
+
+```bash
+$ composer require "react/async:^4@dev || ^3@dev || ^2@dev"
+```
 
 ## Tests
 


### PR DESCRIPTION
This changeset suggests renaming the development branch to `4.x` and adds appropriate installation instructions. In particular, this makes it much easier to install the v4 development version or any version like this:

```bash
$ composer require react/async:^4@dev
$ composer require react/async:"^4@dev || ^3@dev || ^2@dev"
```

The same branch policy has been suggested for our Promise component via https://github.com/reactphp/promise/pull/212. This is also in line with our existing `3.x` and `2.x` branches and means we do not have to update any alias definitions once we would start working on a potential future `5.x`.

From a consumer's perspective, this means installation is now much easier, as targeting `^4@dev` (or `4.x-dev`) is semantically more obvious and safer than using `dev-main`. Additionally, keep in mind that branch names are development artifacts that are subject to change at some point in the future. Once we would decide to rename or delete any of our version branches, the `^4@dev` reference would still be valid as it would also match stable versions if we have any `^4` tags at this point (which is safe to assume at this point).

Once this PR is merged, I will manually rename the `main` branch to `4.x`. Unlike suggested in https://github.com/reactphp/promise/pull/212, the default branch should not be changed. In other words, `4.x` would be the new default branch, as both `3.x` and `2.x` are also still under active development.

Also refs #14 and #11 for `3.x` and `2.x` branch names already used in this project.