### PR TITLE
Improve `async()` to avoid unneeded `futureTick()` calls

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -164,7 +164,7 @@ function async(callable $function): callable
             }
         });
 
-        Loop::futureTick(static fn() => $fiber->start());
+        $fiber->start();
     });
 }
 


### PR DESCRIPTION
This simple changeset improves the `async()` function to avoid any unneeded `futureTick()` calls. This means we can now rely on its execution behavior just like all other promise functions and the `coroutine()` function (#12) provided by this package.

The `async()` function would usually be used together with `await()` (#26). In this case, everything until the first `await()` will be executed in the same instant, just like the `coroutine()` function executes until encountering the first `yield` statement. Likewise, this means that this function now resolves immediately when returning/throwing without an `await()` call.

Given this is one of the core building blocks for fiber-based asynchronous execution, this can have a somewhat significant effect on performance. I consider this to be a first step and have prepared a number of follow-up PRs to improve similar situations in this package. The updated test suite shows this has full code coverage and confirms this is a rather isolated change at the moment.

* Refs #20 for future cancellation support, as a `futureTick()` can not be cancelled and we have to remember additional state in this case. With these changes, this now no longer needed and we can simplify our upcoming cancellation logic.
* Refs #27 which deals with a very similar unexpected tick between asynchronous events. This issue will be addressed in a follow-up PR.
* Builds on top #15 that introduced the fiber-based `async()` function