### PR TITLE
[4.x] Benchmark for async function

### DIFF
--- a/examples/90-async-benchmark.php
+++ b/examples/90-async-benchmark.php
@@ -1,0 +1,15 @@
+<?php
+
+use React\EventLoop\Loop;
+use React\Promise\CancellablePromiseInterface;
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\Timer\sleep;
+
+require 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+ini_set('memory_limit', -1);
+
+for ($i = 0; $i < 1_000_000; $i++) {
+    async(static fn (): bool => true)();
+}


### PR DESCRIPTION
This adds a somewhat boring that measures how much time it takes to spawn 1.000.000 fibers.