### PR TITLE
Improve `await()` to avoid unneeded `futureTick()` calls

### DIFF
--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -24,7 +24,7 @@ final class SimpleFiber implements FiberInterface
             return;
         }
 
-        Loop::futureTick(fn() => $this->fiber->resume($value));
+        $this->fiber->resume($value);
     }
 
     public function throw(\Throwable $throwable): void
@@ -34,7 +34,7 @@ final class SimpleFiber implements FiberInterface
             return;
         }
 
-        Loop::futureTick(fn() => $this->fiber->throw($throwable));
+        $this->fiber->throw($throwable);
     }
 
     public function suspend(): mixed

--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -20,7 +20,11 @@ final class SimpleFiber implements FiberInterface
     public function resume(mixed $value): void
     {
         if ($this->fiber === null) {
-            Loop::futureTick(static fn() => \Fiber::suspend(static fn() => $value));
+            if (\Fiber::getCurrent() !== self::$scheduler) {
+                Loop::futureTick(static fn() => \Fiber::suspend(static fn() => $value));
+            } else {
+                \Fiber::suspend(static fn() => $value);
+            }
             return;
         }
 
@@ -30,7 +34,11 @@ final class SimpleFiber implements FiberInterface
     public function throw(\Throwable $throwable): void
     {
         if ($this->fiber === null) {
-            Loop::futureTick(static fn() => \Fiber::suspend(static fn() => throw $throwable));
+            if (\Fiber::getCurrent() !== self::$scheduler) {
+                Loop::futureTick(static fn() => \Fiber::suspend(static fn() => throw $throwable));
+            } else {
+                \Fiber::suspend(static fn() => throw $throwable);
+            }
             return;
         }
 

--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -20,19 +20,13 @@ final class SimpleFiber implements FiberInterface
 
     public function resume(mixed $value): void
     {
-        if ($this->fiber === null) {
-            $suspend = static fn() => $value;
-            if (\Fiber::getCurrent() !== self::$scheduler) {
-                self::$suspend = $suspend;
-            } else {
-                \Fiber::suspend($suspend);
-            }
-            return;
+        if ($this->fiber !== null) {
+            $this->fiber->resume($value);
+        } else {
+            self::$suspend = static fn() => $value;
         }
 
-        $this->fiber->resume($value);
-
-        if (self::$suspend) {
+        if (self::$suspend !== null && \Fiber::getCurrent() === self::$scheduler) {
             $suspend = self::$suspend;
             self::$suspend = null;
 
@@ -42,19 +36,13 @@ final class SimpleFiber implements FiberInterface
 
     public function throw(\Throwable $throwable): void
     {
-        if ($this->fiber === null) {
-            $suspend = static fn() => throw $throwable;
-            if (\Fiber::getCurrent() !== self::$scheduler) {
-                self::$suspend = $suspend;
-            } else {
-                \Fiber::suspend($suspend);
-            }
-            return;
+        if ($this->fiber !== null) {
+            $this->fiber->throw($throwable);
+        } else {
+            self::$suspend = static fn() => throw $throwable;
         }
 
-        $this->fiber->throw($throwable);
-
-        if (self::$suspend) {
+        if (self::$suspend !== null && \Fiber::getCurrent() === self::$scheduler) {
             $suspend = self::$suspend;
             self::$suspend = null;
 

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Async;
 
 use React;
 use React\EventLoop\Loop;
+use React\Promise\Deferred;
 use React\Promise\Promise;
 use function React\Async\async;
 use function React\Async\await;
@@ -82,6 +83,49 @@ class AsyncTest extends TestCase
         })();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
+    }
+
+    public function testAsyncWithAwaitReturnsReturnsPromiseFulfilledWithValueImmediatelyWhenPromiseIsFulfilled()
+    {
+        $deferred = new Deferred();
+
+        $promise = async(function () use ($deferred) {
+            return await($deferred->promise());
+        })();
+
+        $return = null;
+        $promise->then(function ($value) use (&$return) {
+            $return = $value;
+        });
+
+        $this->assertNull($return);
+
+        $deferred->resolve(42);
+
+        $this->assertEquals(42, $return);
+    }
+
+    public function testAsyncWithAwaitReturnsPromiseRejectedWithExceptionImmediatelyWhenPromiseIsRejected()
+    {
+        $deferred = new Deferred();
+
+        $promise = async(function () use ($deferred) {
+            return await($deferred->promise());
+        })();
+
+        $exception = null;
+        $promise->then(null, function ($reason) use (&$exception) {
+            $exception = $reason;
+        });
+
+        $this->assertNull($exception);
+
+        $deferred->reject(new \RuntimeException('Test', 42));
+
+        $this->assertInstanceof(\RuntimeException::class, $exception);
+        assert($exception instanceof \RuntimeException);
+        $this->assertEquals('Test', $exception->getMessage());
+        $this->assertEquals(42, $exception->getCode());
     }
 
     public function testAsyncReturnsPromiseThatFulfillsWithValueWhenCallbackReturnsAfterAwaitingPromise()

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -143,6 +143,22 @@ class AsyncTest extends TestCase
         $this->assertEquals(42, $value);
     }
 
+    public function testAsyncReturnsPromiseThatRejectsWithExceptionWhenCallbackThrowsAfterAwaitingPromise()
+    {
+        $promise = async(function () {
+            $promise = new Promise(function ($_, $reject) {
+                Loop::addTimer(0.001, fn () => $reject(new \RuntimeException('Foo', 42)));
+            });
+
+            return await($promise);
+        })();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Foo');
+        $this->expectExceptionCode(42);
+        await($promise);
+    }
+
     public function testAsyncReturnsPromiseThatFulfillsWithValueWhenCallbackReturnsAfterAwaitingTwoConcurrentPromises()
     {
         $promise1 = async(function () {

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -25,6 +25,27 @@ class AwaitTest extends TestCase
     /**
      * @dataProvider provideAwaiters
      */
+    public function testAwaitThrowsExceptionWithoutRunningLoop(callable $await)
+    {
+        $now = true;
+        Loop::futureTick(function () use (&$now) {
+            $now = false;
+        });
+
+        $promise = new Promise(function () {
+            throw new \Exception('test');
+        });
+
+        try {
+            $await($promise);
+        } catch (\Exception $e) {
+            $this->assertTrue($now);
+        }
+    }
+
+    /**
+     * @dataProvider provideAwaiters
+     */
     public function testAwaitThrowsUnexpectedValueExceptionWhenPromiseIsRejectedWithFalse(callable $await)
     {
         if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
@@ -89,6 +110,24 @@ class AwaitTest extends TestCase
         });
 
         $this->assertEquals(42, $await($promise));
+    }
+
+    /**
+     * @dataProvider provideAwaiters
+     */
+    public function testAwaitReturnsValueImmediatelyWithoutRunningLoop(callable $await)
+    {
+        $now = true;
+        Loop::futureTick(function () use (&$now) {
+            $now = false;
+        });
+
+        $promise = new Promise(function ($resolve) {
+            $resolve(42);
+        });
+
+        $this->assertEquals(42, $await($promise));
+        $this->assertTrue($now);
     }
 
     /**


### PR DESCRIPTION
This changeset improves the `await()` function to avoid any unneeded `futureTick()` calls. This means we can now rely on its execution behavior just like all other promise functions and the `coroutine()` function (#12) provided by this package.

The `await()` function is used to await the resolution of a promise in fiber-based asynchronous programs. Once the promise is fulfilled (or rejected), execution will now continue immediately. This is also in line with how the `coroutine()` function continues execution immediately after a `yield` statement.

In the previous version, this would have to await the next "loop tick" after the resolution which would be both unexpected from a consumer's perspective and slower in execution. The unexpected behavior has caused a number of issues in the past, most recently #27 which essentially boils down to multiple events happening in the same "tick" which is now supported just fine.

The test suite confirms this only adds new features not previously possible with the old approach and does not otherwise affect existing behavior. Affected code paths have 100% code coverage (I'll look into ensuring we have full code coverage also for unrelated code paths in a separate PR).

This changeset also promises some noticeable performance improvements in synthetic benchmarks, see also #31 for more details about benchmarks. Together with #30, I've seen some 25% performance improvements also inside [Framework X](https://framework-x.org/) for some use cases, but my main motivation is really avoiding unexpected behavior and solving related issues, so I do not expect a significant performance effect for most real-world applications.

I've kept my original commits and a final refactoring in place to ease reviewing and to show how I've gone about removing each group of ticks. The resulting code looks surprisingly straight-forward, but you're look at 8+ hours of work on this PR alone. Enjoy!

* Builds on top of #30 which applies the same changes for the `async()` function. This PR can be considered a follow-up that concludes this entire feature.
* Resolves / closes #27 which describes a situation that depends on multiple events happening in the same "tick" which sparked the discussion.
* Refs #20 for future cancellation support, as a `futureTick()` can not be cancelled and we have to remember additional state in this case. With these changes, this is now no longer needed and we can simplify our upcoming cancellation logic.
* Builds on top #15 that originally introduced the fiber-based `await()` function.