### PR TITLE
Skip cancellation of promise within `Fiber` without cancellation support

### DIFF
--- a/src/FiberMap.php
+++ b/src/FiberMap.php
@@ -25,7 +25,7 @@ final class FiberMap
 
     public static function isCancelled(\Fiber $fiber): bool
     {
-        return self::$status[\spl_object_id($fiber)];
+        return self::$status[\spl_object_id($fiber)] ?? false;
     }
 
     public static function setPromise(\Fiber $fiber, PromiseInterface $promise): void


### PR DESCRIPTION
This changeset makes sure we skip cancellation of promises within `Fiber` instances that do not have cancellation support. This improves interoperability by supporting custom or foreign `Fiber` instances not coming from our `async()` function.

Builds on top of #20