### PR TITLE
[4.x] Add template annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Async\await(…);
 
 ### async()
 
-The `async(callable $function): callable` function can be used to
+The `async(callable():(PromiseInterface<T>|T) $function): (callable():PromiseInterface<T>)` function can be used to
 return an async function for a function that uses [`await()`](#await) internally.
 
 This function is specifically designed to complement the [`await()` function](#await).
@@ -226,7 +226,7 @@ await($promise);
 
 ### await()
 
-The `await(PromiseInterface $promise): mixed` function can be used to
+The `await(PromiseInterface<T> $promise): T` function can be used to
 block waiting for the given `$promise` to be fulfilled.
 
 ```php
@@ -278,7 +278,7 @@ try {
 
 ### coroutine()
 
-The `coroutine(callable $function, mixed ...$args): PromiseInterface<mixed>` function can be used to
+The `coroutine(callable(mixed ...$args):(\Generator|PromiseInterface<T>|T) $function, mixed ...$args): PromiseInterface<T>` function can be used to
 execute a Generator-based coroutine to "await" promises.
 
 ```php
@@ -498,7 +498,7 @@ Loop::addTimer(2.0, function () use ($promise): void {
 
 ### parallel()
 
-The `parallel(iterable<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
+The `parallel(iterable<callable():PromiseInterface<T>> $tasks): PromiseInterface<array<T>>` function can be used
 like this:
 
 ```php
@@ -540,7 +540,7 @@ React\Async\parallel([
 
 ### series()
 
-The `series(iterable<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
+The `series(iterable<callable():PromiseInterface<T>> $tasks): PromiseInterface<array<T>>` function can be used
 like this:
 
 ```php
@@ -582,7 +582,7 @@ React\Async\series([
 
 ### waterfall()
 
-The `waterfall(iterable<callable(mixed=):PromiseInterface<mixed>> $tasks): PromiseInterface<mixed>` function can be used
+The `waterfall(iterable<callable(mixed=):PromiseInterface<T>> $tasks): PromiseInterface<T>` function can be used
 like this:
 
 ```php

--- a/src/FiberMap.php
+++ b/src/FiberMap.php
@@ -6,13 +6,15 @@ use React\Promise\PromiseInterface;
 
 /**
  * @internal
+ *
+ * @template T
  */
 final class FiberMap
 {
     /** @var array<int,bool> */
     private static array $status = [];
 
-    /** @var array<int,PromiseInterface> */
+    /** @var array<int,PromiseInterface<T>> */
     private static array $map = [];
 
     /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
@@ -27,19 +29,28 @@ final class FiberMap
         self::$status[\spl_object_id($fiber)] = true;
     }
 
-    /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
+    /**
+     * @param \Fiber<mixed,mixed,mixed,mixed> $fiber
+     * @param PromiseInterface<T> $promise
+     */
     public static function setPromise(\Fiber $fiber, PromiseInterface $promise): void
     {
         self::$map[\spl_object_id($fiber)] = $promise;
     }
 
-    /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
+    /**
+     * @param \Fiber<mixed,mixed,mixed,mixed> $fiber
+     * @param PromiseInterface<T> $promise
+     */
     public static function unsetPromise(\Fiber $fiber, PromiseInterface $promise): void
     {
         unset(self::$map[\spl_object_id($fiber)]);
     }
 
-    /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
+    /**
+     * @param \Fiber<mixed,mixed,mixed,mixed> $fiber
+     * @return ?PromiseInterface<T>
+     */
     public static function getPromise(\Fiber $fiber): ?PromiseInterface
     {
         return self::$map[\spl_object_id($fiber)] ?? null;

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -413,7 +413,7 @@ class AwaitTest extends TestCase
         })());
     }
 
-    /** @return iterable<string,list<callable(PromiseInterface): mixed>> */
+    /** @return iterable<string,list<callable(PromiseInterface<mixed>): mixed>> */
     public function provideAwaiters(): iterable
     {
         yield 'await' => [static fn (React\Promise\PromiseInterface $promise): mixed => React\Async\await($promise)];

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -22,7 +22,7 @@ class CoroutineTest extends TestCase
     {
         $promise = coroutine(function () {
             if (false) { // @phpstan-ignore-line
-                yield;
+                yield resolve(null);
             }
             return 42;
         });
@@ -53,7 +53,7 @@ class CoroutineTest extends TestCase
     {
         $promise = coroutine(function () {
             if (false) { // @phpstan-ignore-line
-                yield;
+                yield resolve(null);
             }
             throw new \RuntimeException('Foo');
         });
@@ -99,7 +99,7 @@ class CoroutineTest extends TestCase
 
     public function testCoroutineReturnsRejectedPromiseIfFunctionYieldsInvalidValue(): void
     {
-        $promise = coroutine(function () {
+        $promise = coroutine(function () { // @phpstan-ignore-line
             yield 42;
         });
 
@@ -169,7 +169,7 @@ class CoroutineTest extends TestCase
 
         $promise = coroutine(function () {
             if (false) { // @phpstan-ignore-line
-                yield;
+                yield resolve(null);
             }
             return 42;
         });
@@ -249,7 +249,7 @@ class CoroutineTest extends TestCase
 
         gc_collect_cycles();
 
-        $promise = coroutine(function () {
+        $promise = coroutine(function () { // @phpstan-ignore-line
             yield 42;
         });
 

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -12,6 +12,9 @@ class ParallelTest extends TestCase
 {
     public function testParallelWithoutTasks(): void
     {
+        /**
+         * @var array<callable(): React\Promise\PromiseInterface<mixed>> $tasks
+         */
         $tasks = array();
 
         $promise = React\Async\parallel($tasks);

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -12,6 +12,9 @@ class SeriesTest extends TestCase
 {
     public function testSeriesWithoutTasks(): void
     {
+        /**
+         * @var array<callable(): React\Promise\PromiseInterface<mixed>> $tasks
+         */
         $tasks = array();
 
         $promise = React\Async\series($tasks);
@@ -151,6 +154,9 @@ class SeriesTest extends TestCase
         $tasks = new class() implements \IteratorAggregate {
             public int $called = 0;
 
+            /**
+             * @return \Iterator<callable(): React\Promise\PromiseInterface<mixed>>
+             */
             public function getIterator(): \Iterator
             {
                 while (true) { // @phpstan-ignore-line

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -12,6 +12,9 @@ class WaterfallTest extends TestCase
 {
     public function testWaterfallWithoutTasks(): void
     {
+        /**
+         * @var array<callable(): React\Promise\PromiseInterface<mixed>> $tasks
+         */
         $tasks = array();
 
         $promise = React\Async\waterfall($tasks);
@@ -165,6 +168,9 @@ class WaterfallTest extends TestCase
         $tasks = new class() implements \IteratorAggregate {
             public int $called = 0;
 
+            /**
+             * @return \Iterator<callable(): React\Promise\PromiseInterface<mixed>>
+             */
             public function getIterator(): \Iterator
             {
                 while (true) { // @phpstan-ignore-line

--- a/tests/types/async.php
+++ b/tests/types/async.php
@@ -1,0 +1,17 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<bool>', async(static fn (): bool => true)());
+assertType('React\Promise\PromiseInterface<bool>', async(static fn (): PromiseInterface => resolve(true))());
+assertType('React\Promise\PromiseInterface<bool>', async(static fn (): bool => await(resolve(true)))());
+
+assertType('React\Promise\PromiseInterface<int>', async(static fn (int $a): int => $a)(42));
+assertType('React\Promise\PromiseInterface<int>', async(static fn (int $a, int $b): int => $a + $b)(10, 32));
+assertType('React\Promise\PromiseInterface<int>', async(static fn (int $a, int $b, int $c): int => $a + $b + $c)(10, 22, 10));
+assertType('React\Promise\PromiseInterface<int>', async(static fn (int $a, int $b, int $c, int $d): int => $a + $b + $c + $d)(10, 22, 5, 5));
+assertType('React\Promise\PromiseInterface<int>', async(static fn (int $a, int $b, int $c, int $d, int $e): int => $a + $b + $c + $d + $e)(10, 12, 10, 5, 5));

--- a/tests/types/await.php
+++ b/tests/types/await.php
@@ -1,0 +1,23 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\async;
+use function React\Async\await;
+use function React\Promise\resolve;
+
+assertType('bool', await(resolve(true)));
+assertType('bool', await(async(static fn (): bool => true)()));
+assertType('bool', await(async(static fn (): PromiseInterface => resolve(true))()));
+assertType('bool', await(async(static fn (): bool => await(resolve(true)))()));
+
+final class AwaitExampleUser
+{
+    public string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}
+
+assertType('string', await(resolve(new AwaitExampleUser('WyriHaximus')))->name);

--- a/tests/types/coroutine.php
+++ b/tests/types/coroutine.php
@@ -1,0 +1,60 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\coroutine;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    return true;
+}));
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    return resolve(true);
+}));
+
+// assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+//     return (yield resolve(true));
+// }));
+
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function () {
+//     $bool = yield resolve(true);
+//     assertType('bool', $bool);
+
+    return time();
+}));
+
+// assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+//     $bool = yield resolve(true);
+//     assertType('bool', $bool);
+
+//     return $bool;
+// }));
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    yield resolve(time());
+
+    return true;
+}));
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    for ($i = 0; $i <= 10; $i++) {
+        yield resolve($i);
+    }
+
+    return true;
+}));
+
+assertType('React\Promise\PromiseInterface<int>', coroutine(static fn(int $a): int => $a, 42));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static fn(int $a, int $b): int => $a + $b, 10, 32));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static fn(int $a, int $b, int $c): int => $a + $b + $c, 10, 22, 10));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static fn(int $a, int $b, int $c, int $d): int => $a + $b + $c + $d, 10, 22, 5, 5));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static fn(int $a, int $b, int $c, int $d, int $e): int => $a + $b + $c + $d + $e, 10, 12, 10, 5, 5));
+
+assertType('bool', await(coroutine(static function () {
+    return true;
+})));
+
+// assertType('bool', await(coroutine(static function () {
+//     return (yield resolve(true));
+// })));

--- a/tests/types/parallel.php
+++ b/tests/types/parallel.php
@@ -1,0 +1,33 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\parallel;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<array>', parallel([]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', parallel([
+    static fn (): PromiseInterface => resolve(true),
+    static fn (): PromiseInterface => resolve(time()),
+    static fn (): PromiseInterface => resolve(microtime(true)),
+]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', parallel([
+    static fn (): bool => true,
+    static fn (): int => time(),
+    static fn (): float => microtime(true),
+]));
+
+assertType('array<bool|float|int>', await(parallel([
+    static fn (): PromiseInterface => resolve(true),
+    static fn (): PromiseInterface => resolve(time()),
+    static fn (): PromiseInterface => resolve(microtime(true)),
+])));
+
+assertType('array<bool|float|int>', await(parallel([
+    static fn (): bool => true,
+    static fn (): int => time(),
+    static fn (): float => microtime(true),
+])));

--- a/tests/types/series.php
+++ b/tests/types/series.php
@@ -1,0 +1,33 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\series;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<array>', series([]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', series([
+    static fn (): PromiseInterface => resolve(true),
+    static fn (): PromiseInterface => resolve(time()),
+    static fn (): PromiseInterface => resolve(microtime(true)),
+]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', series([
+    static fn (): bool => true,
+    static fn (): int => time(),
+    static fn (): float => microtime(true),
+]));
+
+assertType('array<bool|float|int>', await(series([
+    static fn (): PromiseInterface => resolve(true),
+    static fn (): PromiseInterface => resolve(time()),
+    static fn (): PromiseInterface => resolve(microtime(true)),
+])));
+
+assertType('array<bool|float|int>', await(series([
+    static fn (): bool => true,
+    static fn (): int => time(),
+    static fn (): float => microtime(true),
+])));

--- a/tests/types/waterfall.php
+++ b/tests/types/waterfall.php
@@ -1,0 +1,42 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\waterfall;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<null>', waterfall([]));
+
+assertType('React\Promise\PromiseInterface<float>', waterfall([
+    static fn (): PromiseInterface => resolve(microtime(true)),
+]));
+
+assertType('React\Promise\PromiseInterface<float>', waterfall([
+    static fn (): float => microtime(true),
+]));
+
+// Desired, but currently unsupported with the current set of templates
+//assertType('React\Promise\PromiseInterface<float>', waterfall([
+//    static fn (): PromiseInterface => resolve(true),
+//    static fn (bool $bool): PromiseInterface => resolve(time()),
+//    static fn (int $int): PromiseInterface => resolve(microtime(true)),
+//]));
+
+assertType('float', await(waterfall([
+    static fn (): PromiseInterface => resolve(microtime(true)),
+])));
+
+// Desired, but currently unsupported with the current set of templates
+//assertType('float', await(waterfall([
+//    static fn (): PromiseInterface => resolve(true),
+//    static fn (bool $bool): PromiseInterface => resolve(time()),
+//    static fn (int $int): PromiseInterface => resolve(microtime(true)),
+//])));
+
+// assertType('React\Promise\PromiseInterface<null>', waterfall(new EmptyIterator()));
+
+$iterator = new ArrayIterator([
+    static fn (): PromiseInterface => resolve(true),
+]);
+assertType('React\Promise\PromiseInterface<bool>', waterfall($iterator));


### PR DESCRIPTION
These annotations will aid static analyses like PHPStan and Psalm to enhance type-safety for this project and projects depending on it

These changes make the following example understandable by PHPStan:

```php
final readonly class User
{
    public function __construct(
        public string $name,
    )
}

/**
 * \React\Promise\PromiseInterface<User>
 */
function getCurrentUserFromDatabase(): \React\Promise\PromiseInterface
{
    // The following line would do the database query and fetch the result from it
    // but keeping it simple for the sake of the example.
    return \React\Promise\resolve(new User('WyriHaximus'));
}

// For the sake of this example we're going to assume the following code runs
// in \React\Async\async call
echo await(getCurrentUserFromDatabase())->name; // This echos: WyriHaximus
```

This PR builds on the discussion at https://github.com/vimeo/psalm/discussions/7559 and the following PR's 
https://github.com/reactphp/promise/pull/247, https://github.com/reactphp/promise/pull/246, and others down the line.