### PR TITLE
[3.x] Support iterable type for `parallel()` + `series()` + `waterfall()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ $promise->then(function (int $bytes) {
 
 ### parallel()
 
-The `parallel(array<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `parallel(iterable<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
 like this:
 
 ```php
@@ -250,7 +250,7 @@ React\Async\parallel([
 
 ### series()
 
-The `series(array<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `series(iterable<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
 like this:
 
 ```php
@@ -292,7 +292,7 @@ React\Async\series([
 
 ### waterfall()
 
-The `waterfall(array<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<mixed,Exception>` function can be used
+The `waterfall(iterable<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<mixed,Exception>` function can be used
 like this:
 
 ```php

--- a/src/functions.php
+++ b/src/functions.php
@@ -282,10 +282,10 @@ function coroutine(callable $function, ...$args): PromiseInterface
 }
 
 /**
- * @param array<callable():PromiseInterface<mixed,Exception>> $tasks
+ * @param iterable<callable():PromiseInterface<mixed,Exception>> $tasks
  * @return PromiseInterface<array<mixed>,Exception>
  */
-function parallel(array $tasks): PromiseInterface
+function parallel(iterable $tasks): PromiseInterface
 {
     $pending = [];
     $deferred = new Deferred(function () use (&$pending) {
@@ -298,6 +298,10 @@ function parallel(array $tasks): PromiseInterface
     });
     $results = [];
     $errored = false;
+
+    if (!\is_array($tasks)) {
+        $tasks = \iterator_to_array($tasks);
+    }
 
     $numTasks = count($tasks);
     if (0 === $numTasks) {
@@ -340,10 +344,10 @@ function parallel(array $tasks): PromiseInterface
 }
 
 /**
- * @param array<callable():PromiseInterface<mixed,Exception>> $tasks
+ * @param iterable<callable():PromiseInterface<mixed,Exception>> $tasks
  * @return PromiseInterface<array<mixed>,Exception>
  */
-function series(array $tasks): PromiseInterface
+function series(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
@@ -353,6 +357,10 @@ function series(array $tasks): PromiseInterface
         $pending = null;
     });
     $results = [];
+
+    if (!\is_array($tasks)) {
+        $tasks = \iterator_to_array($tasks);
+    }
 
     /** @var callable():void $next */
     $taskCallback = function ($result) use (&$results, &$next) {
@@ -380,10 +388,10 @@ function series(array $tasks): PromiseInterface
 }
 
 /**
- * @param array<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks
+ * @param iterable<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks
  * @return PromiseInterface<mixed,Exception>
  */
-function waterfall(array $tasks): PromiseInterface
+function waterfall(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
@@ -392,6 +400,10 @@ function waterfall(array $tasks): PromiseInterface
         }
         $pending = null;
     });
+
+    if (!\is_array($tasks)) {
+        $tasks = \iterator_to_array($tasks);
+    }
 
     /** @var callable $next */
     $next = function ($value = null) use (&$tasks, &$next, $deferred, &$pending) {

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Async;
 use React;
 use React\EventLoop\Loop;
 use React\Promise\Promise;
+use function React\Promise\reject;
 
 class SeriesTest extends TestCase
 {
@@ -123,6 +124,47 @@ class SeriesTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('whoops')));
 
         $this->assertSame(1, $called);
+    }
+
+    public function testSeriesWithErrorFromInfiniteGeneratorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    {
+        $called = 0;
+
+        $tasks = (function () use (&$called) {
+            while (true) {
+                yield function () use (&$called) {
+                    return reject(new \RuntimeException('Rejected ' . ++$called));
+                };
+            }
+        })();
+
+        $promise = React\Async\series($tasks);
+
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Rejected 1')));
+
+        $this->assertSame(1, $called);
+    }
+
+    public function testSeriesWithErrorFromInfiniteIteratorAggregateReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    {
+        $tasks = new class() implements \IteratorAggregate {
+            public $called = 0;
+
+            public function getIterator(): \Iterator
+            {
+                while (true) {
+                    yield function () {
+                        return reject(new \RuntimeException('Rejected ' . ++$this->called));
+                    };
+                }
+            }
+        };
+
+        $promise = React\Async\series($tasks);
+
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Rejected 1')));
+
+        $this->assertSame(1, $tasks->called);
     }
 
     public function testSeriesWillCancelFirstPendingPromiseWhenCallingCancelOnResultingPromise()


### PR DESCRIPTION
This changeset adds support for the `iterable` type for `parallel()` + `series()` + `waterfall()`. Instead of only accepting an `array`, each function now also accepts instances implementing `Traversable` such as `Iterator` and `Generator` instances.

This is a pure feature addition that does not break BC. With these changes applied, our API is now in line with the other promise APIs (see https://github.com/reactphp/promise/pull/225). 

This PR targets Async v3 as the minimum API version. If this gets merged, I'll file a follow-up PR to apply the same changes also for Async v4.

The first commit highlights how this is essentially only a new type definition and a call to `iterator_to_array()`. The second commit then takes advantage of a more iterative approach that uses less memory and also supports consuming infinite iterators if the resulting promise settles. The test suite confirms this has 100% code coverage.

Refs #41
Builds on top of #11
Refs https://twitter.com/another_clue/status/1535652835521613824 (UML of iterators in PHP)