### PR TITLE
[3.x] Forward compatibility with upcoming Promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=7.1",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.8 || ^1.2.1"
+        "react/promise": "^3.0 || ^2.8 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^7.5"

--- a/src/functions.php
+++ b/src/functions.php
@@ -3,7 +3,6 @@
 namespace React\Async;
 
 use React\EventLoop\Loop;
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use function React\Promise\reject;
@@ -235,7 +234,7 @@ function coroutine(callable $function, ...$args): PromiseInterface
     $promise = null;
     $deferred = new Deferred(function () use (&$promise) {
         // cancel pending promise(s) as long as generator function keeps yielding
-        while ($promise instanceof CancellablePromiseInterface) {
+        while ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
             $temp = $promise;
             $promise = null;
             $temp->cancel();
@@ -290,7 +289,7 @@ function parallel(array $tasks): PromiseInterface
     $pending = [];
     $deferred = new Deferred(function () use (&$pending) {
         foreach ($pending as $promise) {
-            if ($promise instanceof CancellablePromiseInterface) {
+            if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
                 $promise->cancel();
             }
         }
@@ -309,7 +308,7 @@ function parallel(array $tasks): PromiseInterface
         $deferred->reject($error);
 
         foreach ($pending as $promise) {
-            if ($promise instanceof CancellablePromiseInterface) {
+            if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
                 $promise->cancel();
             }
         }
@@ -347,7 +346,7 @@ function series(array $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
-        if ($pending instanceof CancellablePromiseInterface) {
+        if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
             $pending->cancel();
         }
         $pending = null;
@@ -387,7 +386,7 @@ function waterfall(array $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
-        if ($pending instanceof CancellablePromiseInterface) {
+        if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
             $pending->cancel();
         }
         $pending = null;

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -87,7 +87,7 @@ class SeriesTest extends TestCase
         $tasks = array(
             function () {
                 return new Promise(function ($resolve) {
-                    $resolve();
+                    $resolve(null);
                 });
             },
             function () use (&$cancelled) {

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -94,7 +94,7 @@ class WaterfallTest extends TestCase
         $tasks = array(
             function () {
                 return new Promise(function ($resolve) {
-                    $resolve();
+                    $resolve(null);
                 });
             },
             function () use (&$cancelled) {


### PR DESCRIPTION
Builds on top of https://github.com/reactphp/promise/pull/75 and https://github.com/reactphp/promise/pull/213
Changes cherry-picked from #46 for 2.x, but also refs cancellation of `coroutine()` (see #13 and #42)
Refs #43