### PR TITLE
[4.x] Forward compatibility with upcoming Promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.1",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.8 || ^1.2.1"
+        "react/promise": "^3.0 || ^2.8 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,8 +2,6 @@
 
 namespace React\Async;
 
-use React\EventLoop\Loop;
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
@@ -199,7 +197,7 @@ function async(callable $function): callable
         }, function () use (&$fiber): void {
             FiberMap::cancel($fiber);
             $promise = FiberMap::getPromise($fiber);
-            if ($promise instanceof CancellablePromiseInterface) {
+            if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
                 $promise->cancel();
             }
         });
@@ -535,7 +533,7 @@ function parallel(iterable $tasks): PromiseInterface
     $pending = [];
     $deferred = new Deferred(function () use (&$pending) {
         foreach ($pending as $promise) {
-            if ($promise instanceof CancellablePromiseInterface) {
+            if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
                 $promise->cancel();
             }
         }
@@ -549,7 +547,7 @@ function parallel(iterable $tasks): PromiseInterface
         $deferred->reject($error);
 
         foreach ($pending as $promise) {
-            if ($promise instanceof CancellablePromiseInterface) {
+            if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
                 $promise->cancel();
             }
         }
@@ -593,7 +591,7 @@ function series(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
-        if ($pending instanceof CancellablePromiseInterface) {
+        if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
             $pending->cancel();
         }
         $pending = null;
@@ -644,7 +642,7 @@ function waterfall(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
-        if ($pending instanceof CancellablePromiseInterface) {
+        if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
             $pending->cancel();
         }
         $pending = null;

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -174,7 +174,7 @@ class SeriesTest extends TestCase
         $tasks = array(
             function () {
                 return new Promise(function ($resolve) {
-                    $resolve();
+                    $resolve(null);
                 });
             },
             function () use (&$cancelled) {

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -188,7 +188,7 @@ class WaterfallTest extends TestCase
         $tasks = array(
             function () {
                 return new Promise(function ($resolve) {
-                    $resolve();
+                    $resolve(null);
                 });
             },
             function () use (&$cancelled) {


### PR DESCRIPTION
~~Marking this as WIP as the tests currently fail with Promise v3. I've marked the affected tests as incomplete for now, but before merging, the root cause should be fixed instead.~~ Solved via https://github.com/reactphp/promise/pull/229.

Builds on top of https://github.com/reactphp/promise/pull/75 and https://github.com/reactphp/promise/pull/213 ~~and https://github.com/reactphp/promise-timer/pull/54~~
Changes cherry-picked from #47 for 3.x, but also refs cancellation of `async()` (see #20 and #42)
Refs #43