### PR TITLE
[4.x] Support iterable type for `parallel()` + `series()` + `waterfall()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ $promise->then(function (int $bytes) {
 
 ### parallel()
 
-The `parallel(array<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `parallel(iterable<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
 like this:
 
 ```php
@@ -438,7 +438,7 @@ React\Async\parallel([
 
 ### series()
 
-The `series(array<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `series(iterable<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
 like this:
 
 ```php
@@ -480,7 +480,7 @@ React\Async\series([
 
 ### waterfall()
 
-The `waterfall(array<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<mixed,Exception>` function can be used
+The `waterfall(iterable<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<mixed,Exception>` function can be used
 like this:
 
 ```php

--- a/src/functions.php
+++ b/src/functions.php
@@ -533,10 +533,10 @@ function coroutine(callable $function, mixed ...$args): PromiseInterface
 }
 
 /**
- * @param array<callable():PromiseInterface<mixed,Exception>> $tasks
+ * @param iterable<callable():PromiseInterface<mixed,Exception>> $tasks
  * @return PromiseInterface<array<mixed>,Exception>
  */
-function parallel(array $tasks): PromiseInterface
+function parallel(iterable $tasks): PromiseInterface
 {
     $pending = [];
     $deferred = new Deferred(function () use (&$pending) {
@@ -549,6 +549,10 @@ function parallel(array $tasks): PromiseInterface
     });
     $results = [];
     $errored = false;
+
+    if (!\is_array($tasks)) {
+        $tasks = \iterator_to_array($tasks);
+    }
 
     $numTasks = count($tasks);
     if (0 === $numTasks) {
@@ -591,10 +595,10 @@ function parallel(array $tasks): PromiseInterface
 }
 
 /**
- * @param array<callable():PromiseInterface<mixed,Exception>> $tasks
+ * @param iterable<callable():PromiseInterface<mixed,Exception>> $tasks
  * @return PromiseInterface<array<mixed>,Exception>
  */
-function series(array $tasks): PromiseInterface
+function series(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
@@ -604,6 +608,10 @@ function series(array $tasks): PromiseInterface
         $pending = null;
     });
     $results = [];
+
+    if (!\is_array($tasks)) {
+        $tasks = \iterator_to_array($tasks);
+    }
 
     /** @var callable():void $next */
     $taskCallback = function ($result) use (&$results, &$next) {
@@ -631,10 +639,10 @@ function series(array $tasks): PromiseInterface
 }
 
 /**
- * @param array<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks
+ * @param iterable<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks
  * @return PromiseInterface<mixed,Exception>
  */
-function waterfall(array $tasks): PromiseInterface
+function waterfall(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
@@ -643,6 +651,10 @@ function waterfall(array $tasks): PromiseInterface
         }
         $pending = null;
     });
+
+    if (!\is_array($tasks)) {
+        $tasks = \iterator_to_array($tasks);
+    }
 
     /** @var callable $next */
     $next = function ($value = null) use (&$tasks, &$next, $deferred, &$pending) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -548,19 +548,10 @@ function parallel(iterable $tasks): PromiseInterface
         $pending = [];
     });
     $results = [];
-    $errored = false;
+    $continue = true;
 
-    if (!\is_array($tasks)) {
-        $tasks = \iterator_to_array($tasks);
-    }
-
-    $numTasks = count($tasks);
-    if (0 === $numTasks) {
-        $deferred->resolve($results);
-    }
-
-    $taskErrback = function ($error) use (&$pending, $deferred, &$errored) {
-        $errored = true;
+    $taskErrback = function ($error) use (&$pending, $deferred, &$continue) {
+        $continue = false;
         $deferred->reject($error);
 
         foreach ($pending as $promise) {
@@ -572,23 +563,29 @@ function parallel(iterable $tasks): PromiseInterface
     };
 
     foreach ($tasks as $i => $task) {
-        $taskCallback = function ($result) use (&$results, &$pending, $numTasks, $i, $deferred) {
+        $taskCallback = function ($result) use (&$results, &$pending, &$continue, $i, $deferred) {
             $results[$i] = $result;
+            unset($pending[$i]);
 
-            if (count($results) === $numTasks) {
+            if (!$pending && !$continue) {
                 $deferred->resolve($results);
             }
         };
 
-        $promise = call_user_func($task);
+        $promise = \call_user_func($task);
         assert($promise instanceof PromiseInterface);
         $pending[$i] = $promise;
 
         $promise->then($taskCallback, $taskErrback);
 
-        if ($errored) {
+        if (!$continue) {
             break;
         }
+    }
+
+    $continue = false;
+    if (!$pending) {
+        $deferred->resolve($results);
     }
 
     return $deferred->promise();
@@ -609,8 +606,9 @@ function series(iterable $tasks): PromiseInterface
     });
     $results = [];
 
-    if (!\is_array($tasks)) {
-        $tasks = \iterator_to_array($tasks);
+    if ($tasks instanceof \IteratorAggregate) {
+        $tasks = $tasks->getIterator();
+        assert($tasks instanceof \Iterator);
     }
 
     /** @var callable():void $next */
@@ -620,13 +618,19 @@ function series(iterable $tasks): PromiseInterface
     };
 
     $next = function () use (&$tasks, $taskCallback, $deferred, &$results, &$pending) {
-        if (0 === count($tasks)) {
+        if ($tasks instanceof \Iterator ? !$tasks->valid() : !$tasks) {
             $deferred->resolve($results);
             return;
         }
 
-        $task = array_shift($tasks);
-        $promise = call_user_func($task);
+        if ($tasks instanceof \Iterator) {
+            $task = $tasks->current();
+            $tasks->next();
+        } else {
+            $task = \array_shift($tasks);
+        }
+
+        $promise = \call_user_func($task);
         assert($promise instanceof PromiseInterface);
         $pending = $promise;
 
@@ -652,19 +656,26 @@ function waterfall(iterable $tasks): PromiseInterface
         $pending = null;
     });
 
-    if (!\is_array($tasks)) {
-        $tasks = \iterator_to_array($tasks);
+    if ($tasks instanceof \IteratorAggregate) {
+        $tasks = $tasks->getIterator();
+        assert($tasks instanceof \Iterator);
     }
 
     /** @var callable $next */
     $next = function ($value = null) use (&$tasks, &$next, $deferred, &$pending) {
-        if (0 === count($tasks)) {
+        if ($tasks instanceof \Iterator ? !$tasks->valid() : !$tasks) {
             $deferred->resolve($value);
             return;
         }
 
-        $task = array_shift($tasks);
-        $promise = call_user_func_array($task, func_get_args());
+        if ($tasks instanceof \Iterator) {
+            $task = $tasks->current();
+            $tasks->next();
+        } else {
+            $task = \array_shift($tasks);
+        }
+
+        $promise = \call_user_func_array($task, func_get_args());
         assert($promise instanceof PromiseInterface);
         $pending = $promise;
 

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Async;
 use React;
 use React\EventLoop\Loop;
 use React\Promise\Promise;
+use function React\Promise\reject;
 
 class SeriesTest extends TestCase
 {
@@ -123,6 +124,47 @@ class SeriesTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('whoops')));
 
         $this->assertSame(1, $called);
+    }
+
+    public function testSeriesWithErrorFromInfiniteGeneratorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    {
+        $called = 0;
+
+        $tasks = (function () use (&$called) {
+            while (true) {
+                yield function () use (&$called) {
+                    return reject(new \RuntimeException('Rejected ' . ++$called));
+                };
+            }
+        })();
+
+        $promise = React\Async\series($tasks);
+
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Rejected 1')));
+
+        $this->assertSame(1, $called);
+    }
+
+    public function testSeriesWithErrorFromInfiniteIteratorAggregateReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    {
+        $tasks = new class() implements \IteratorAggregate {
+            public $called = 0;
+
+            public function getIterator(): \Iterator
+            {
+                while (true) {
+                    yield function () {
+                        return reject(new \RuntimeException('Rejected ' . ++$this->called));
+                    };
+                }
+            }
+        };
+
+        $promise = React\Async\series($tasks);
+
+        $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Rejected 1')));
+
+        $this->assertSame(1, $tasks->called);
     }
 
     public function testSeriesWillCancelFirstPendingPromiseWhenCallingCancelOnResultingPromise()


### PR DESCRIPTION
This changeset adds support for the `iterable` type for `parallel()` + `series()` + `waterfall()`. Instead of only accepting an `array`, each function now also accepts instances implementing `Traversable` such as `Iterator` and `Generator` instances.

This is a pure feature addition that does not break BC. With these changes applied, our API is now in line with the other promise APIs (see https://github.com/reactphp/promise/pull/225). 

This PR targets Async v4 as the minimum API version. The same changes have been merged for Async v3 already (https://github.com/reactphp/async/pull/45).

The first commit highlights how this is essentially only a new type definition and a call to `iterator_to_array()`. The second commit then takes advantage of a more iterative approach that uses less memory and also supports consuming infinite iterators if the resulting promise settles. The test suite confirms this has 100% code coverage.

Refs #41
Builds on top of #11
Refs https://twitter.com/another_clue/status/1535652835521613824 (UML of iterators in PHP)