### PR TITLE
[3.x] Consistent cancellation semantics for `coroutine()`

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -233,12 +233,10 @@ function coroutine(callable $function, ...$args): PromiseInterface
 
     $promise = null;
     $deferred = new Deferred(function () use (&$promise) {
-        // cancel pending promise(s) as long as generator function keeps yielding
-        while ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
-            $temp = $promise;
-            $promise = null;
-            $temp->cancel();
+        if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
+            $promise->cancel();
         }
+        $promise = null;
     });
 
     /** @var callable $next */


### PR DESCRIPTION
This changeset ensures we're using consistent cancellation semantics for `coroutine()`. In particular, calling `cancel()` on the resulting promise will now try to cancel the first pending operation only. Cancelling a pending operation would usually throw an exception and thus reject the resulting promise. If this exception in caught inside the coroutine and another operation is started or if the pending operation does not support cancellation, the coroutine may continue executing.

Refs #42
Builds on top of #12, #13 and #47