### PR TITLE
[4.x] Consistent cancellation semantics for `async()` and `coroutine()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,18 +205,20 @@ $promise->then(function (int $bytes) {
 });
 ```
 
-Promises returned by `async()` can be cancelled, and when done any currently and future awaited promise inside that and 
-any nested fibers with their awaited promises will also be cancelled. As such the following example will only output 
-`ab` as the [`sleep()`](https://reactphp.org/promise-timer/#sleep) between `a` and `b` is cancelled throwing a timeout 
-exception that bubbles up through the fibers ultimately to the end user through the [`await()`](#await) on the last line 
-of the example.
+The returned promise is implemented in such a way that it can be cancelled
+when it is still pending. Cancelling a pending promise will cancel any awaited
+promises inside that fiber or any nested fibers. As such, the following example
+will only output `ab` and cancel the pending [`sleep()`](https://reactphp.org/promise-timer/#sleep).
+The [`await()`](#await) calls in this example would throw a `RuntimeException`
+from the cancelled [`sleep()`](https://reactphp.org/promise-timer/#sleep) call
+that bubbles up through the fibers.
 
 ```php
 $promise = async(static function (): int {
     echo 'a';
     await(async(static function(): void {
         echo 'b';
-        await(sleep(2));
+        await(React\Promise\Timer\sleep(2));
         echo 'c';
     })());
     echo 'd';

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "react/promise": "^2.8 || ^1.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "react/promise-timer": "^1.8"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/FiberMap.php
+++ b/src/FiberMap.php
@@ -23,11 +23,6 @@ final class FiberMap
         self::$status[\spl_object_id($fiber)] = true;
     }
 
-    public static function isCancelled(\Fiber $fiber): bool
-    {
-        return self::$status[\spl_object_id($fiber)] ?? false;
-    }
-
     public static function setPromise(\Fiber $fiber, PromiseInterface $promise): void
     {
         self::$map[\spl_object_id($fiber)] = $promise;
@@ -36,11 +31,6 @@ final class FiberMap
     public static function unsetPromise(\Fiber $fiber, PromiseInterface $promise): void
     {
         unset(self::$map[\spl_object_id($fiber)]);
-    }
-
-    public static function has(\Fiber $fiber): bool
-    {
-        return array_key_exists(\spl_object_id($fiber), self::$map);
     }
 
     public static function getPromise(\Fiber $fiber): ?PromiseInterface

--- a/src/functions.php
+++ b/src/functions.php
@@ -485,12 +485,10 @@ function coroutine(callable $function, mixed ...$args): PromiseInterface
 
     $promise = null;
     $deferred = new Deferred(function () use (&$promise) {
-        // cancel pending promise(s) as long as generator function keeps yielding
-        while ($promise instanceof CancellablePromiseInterface) {
-            $temp = $promise;
-            $promise = null;
-            $temp->cancel();
+        if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
+            $promise->cancel();
         }
+        $promise = null;
     });
 
     /** @var callable $next */

--- a/src/functions.php
+++ b/src/functions.php
@@ -148,20 +148,20 @@ use function React\Promise\resolve;
  * });
  * ```
  *
- * Promises returned by `async()` can be cancelled, and when done any currently
- * and future awaited promise inside that and any nested fibers with their
- * awaited promises will also be cancelled. As such the following example will
- * only output `ab` as the [`sleep()`](https://reactphp.org/promise-timer/#sleep)
- * between `a` and `b` is cancelled throwing a timeout exception that bubbles up
- * through the fibers ultimately to the end user through the [`await()`](#await)
- * on the last line of the example.
+ * The returned promise is implemented in such a way that it can be cancelled
+ * when it is still pending. Cancelling a pending promise will cancel any awaited
+ * promises inside that fiber or any nested fibers. As such, the following example
+ * will only output `ab` and cancel the pending [`sleep()`](https://reactphp.org/promise-timer/#sleep).
+ * The [`await()`](#await) calls in this example would throw a `RuntimeException`
+ * from the cancelled [`sleep()`](https://reactphp.org/promise-timer/#sleep) call
+ * that bubbles up through the fibers.
  *
  * ```php
  * $promise = async(static function (): int {
  *     echo 'a';
  *     await(async(static function(): void {
  *         echo 'b';
- *         await(sleep(2));
+ *         await(React\Promise\Timer\sleep(2));
  *         echo 'c';
  *     })());
  *     echo 'd';
@@ -276,10 +276,6 @@ function await(PromiseInterface $promise): mixed
     $resolvedValue = null;
     $rejectedThrowable = null;
     $lowLevelFiber = \Fiber::getCurrent();
-
-    if ($lowLevelFiber !== null && FiberMap::isCancelled($lowLevelFiber) && $promise instanceof CancellablePromiseInterface) {
-        $promise->cancel();
-    }
 
     $promise->then(
         function (mixed $value) use (&$resolved, &$resolvedValue, &$fiber, $lowLevelFiber, $promise): void {

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -379,7 +379,9 @@ class AwaitTest extends TestCase
     {
         $await(async(function () use ($await): int {
             $fiber = \Fiber::getCurrent();
-            $await(React\Promise\Timer\sleep(0.01));
+            $await(new Promise(function ($resolve) {
+                Loop::addTimer(0.01, fn() => $resolve(null));
+            }));
             $this->assertNull(React\Async\FiberMap::getPromise($fiber));
 
             return time();


### PR DESCRIPTION
This changeset ensures we're using consistent cancellation semantics for `async()` and `coroutine()`. In particular, calling `cancel()` on the resulting promise will now try to cancel the first pending operation only. Cancelling a pending operation would usually throw an exception and thus reject the resulting promise. If this exception in caught inside the fiber/coroutine and another operation is started or if the pending operation does not support cancellation, the fiber/coroutine may continue executing.

Refs #42
Changes for `coroutine()` cherry-picked from #54 for 3.x, but also refs cancellation of `async()` (see #20 and #34)
Builds on top of #20, #34 and #48 