### PR TITLE
Improve examples for `async()` and `await()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,15 @@ will still be blocked, but everything outside this function can be executed
 asynchronously without blocking:
 
 ```php
-Loop::addTimer(0.5, React\Async\async(function() {
+Loop::addTimer(0.5, React\Async\async(function () {
     echo 'a';
-    React\async\await(React\Promise\Timer\sleep(1.0));
+    React\Async\await(React\Promise\Timer\sleep(1.0));
     echo 'c';
 }));
 
-Loop::addTimer(1.0, fn() => echo 'b');
+Loop::addTimer(1.0, function () {
+    echo 'b';
+});
 
 // prints "a" at t=0.5s
 // prints "b" at t=1.0s
@@ -98,13 +100,15 @@ In particular, this function does not "magically" make any blocking function
 non-blocking:
 
 ```php
-Loop::addTimer(0.5, React\Async\async(function() {
+Loop::addTimer(0.5, React\Async\async(function () {
     echo 'a';
     sleep(1); // broken: using PHP's blocking sleep() for demonstration purposes
     echo 'c';
 }));
 
-Loop::addTimer(1.0, fn() => echo 'b');
+Loop::addTimer(1.0, function () {
+    echo 'b';
+});
 
 // prints "a" at t=0.5s
 // prints "c" at t=1.5s: Correct timing, but wrong order
@@ -216,7 +220,7 @@ that bubbles up through the fibers.
 ```php
 $promise = async(static function (): int {
     echo 'a';
-    await(async(static function(): void {
+    await(async(static function (): void {
         echo 'b';
         await(React\Promise\Timer\sleep(2));
         echo 'c';
@@ -247,13 +251,15 @@ call. Everything inside this function will still be blocked, but everything
 outside this function can be executed asynchronously without blocking:
 
 ```php
-Loop::addTimer(0.5, React\Async\async(function() {
+Loop::addTimer(0.5, React\Async\async(function () {
     echo 'a';
-    React\async\await(React\Promise\Timer\sleep(1.0));
+    React\Async\await(React\Promise\Timer\sleep(1.0));
     echo 'c';
 }));
 
-Loop::addTimer(1.0, fn() => echo 'b');
+Loop::addTimer(1.0, function () {
+    echo 'b';
+});
 
 // prints "a" at t=0.5s
 // prints "b" at t=1.0s

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,13 +19,15 @@ use function React\Promise\resolve;
  * asynchronously without blocking:
  *
  * ```php
- * Loop::addTimer(0.5, React\Async\async(function() {
+ * Loop::addTimer(0.5, React\Async\async(function () {
  *     echo 'a';
- *     React\async\await(React\Promise\Timer\sleep(1.0));
+ *     React\Async\await(React\Promise\Timer\sleep(1.0));
  *     echo 'c';
  * }));
  *
- * Loop::addTimer(1.0, fn() => echo 'b');
+ * Loop::addTimer(1.0, function () {
+ *     echo 'b';
+ * });
  *
  * // prints "a" at t=0.5s
  * // prints "b" at t=1.0s
@@ -39,13 +41,15 @@ use function React\Promise\resolve;
  * non-blocking:
  *
  * ```php
- * Loop::addTimer(0.5, React\Async\async(function() {
+ * Loop::addTimer(0.5, React\Async\async(function () {
  *     echo 'a';
  *     sleep(1); // broken: using PHP's blocking sleep() for demonstration purposes
  *     echo 'c';
  * }));
  *
- * Loop::addTimer(1.0, fn() => echo 'b');
+ * Loop::addTimer(1.0, function () {
+ *     echo 'b';
+ * });
  *
  * // prints "a" at t=0.5s
  * // prints "c" at t=1.5s: Correct timing, but wrong order
@@ -157,7 +161,7 @@ use function React\Promise\resolve;
  * ```php
  * $promise = async(static function (): int {
  *     echo 'a';
- *     await(async(static function(): void {
+ *     await(async(static function (): void {
  *         echo 'b';
  *         await(React\Promise\Timer\sleep(2));
  *         echo 'c';
@@ -227,13 +231,15 @@ function async(callable $function): callable
  * outside this function can be executed asynchronously without blocking:
  *
  * ```php
- * Loop::addTimer(0.5, React\Async\async(function() {
+ * Loop::addTimer(0.5, React\Async\async(function () {
  *     echo 'a';
- *     React\async\await(React\Promise\Timer\sleep(1.0));
+ *     React\Async\await(React\Promise\Timer\sleep(1.0));
  *     echo 'c';
  * }));
  *
- * Loop::addTimer(1.0, fn() => echo 'b');
+ * Loop::addTimer(1.0, function () {
+ *     echo 'b';
+ * });
  *
  * // prints "a" at t=0.5s
  * // prints "b" at t=1.0s

--- a/tests/AsyncTest.php
+++ b/tests/AsyncTest.php
@@ -243,9 +243,9 @@ class AsyncTest extends TestCase
 
         $promise = async(static function (): int {
             echo 'a';
-            await(async(static function(): void {
+            await(async(static function (): void {
                 echo 'b';
-                await(async(static function(): void {
+                await(async(static function (): void {
                     echo 'c';
                     await(new Promise(function () { }, function () {
                         throw new \RuntimeException('Operation cancelled');


### PR DESCRIPTION
This simple changeset improves the examples for `async()` and `await()` as discussed in #56. The incorrect examples were originally added in #26 and this only affects the `4.x` branch.