### PR TITLE
[3.x] Test on PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.2
           - 8.1
           - 8.0
           - 7.4


### PR DESCRIPTION
With PHP 8.2 coming out later this year, we should be reading for it's release to ensure all out code works on it.

Refs: https://github.com/reactphp/event-loop/pull/258
Refs #61 for same changes in v4