### PR TITLE
Add execution order test

### DIFF
--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -13,6 +13,30 @@ class AwaitTest extends TestCase
     /**
      * @dataProvider provideAwaiters
      */
+    public function testExecutionOrder(callable $await)
+    {
+        self::expectOutputString('acbd');
+
+        $deferred = new React\Promise\Deferred();
+
+        $promises[] = React\Async\async(function () use ($deferred, $await) {
+            print 'a';
+            $await($deferred->promise());
+            print 'b';
+        })();
+
+        $promises[] = React\Async\async(function () use ($deferred) {
+            print 'c';
+            $deferred->resolve();
+            print 'd';
+        })();
+
+        $await(React\Promise\all($promises));
+    }
+
+    /**
+     * @dataProvider provideAwaiters
+     */
     public function testAwaitThrowsExceptionWhenPromiseIsRejectedWithException(callable $await)
     {
         $promise = new Promise(function () {

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -7,6 +7,7 @@ use React\EventLoop\Loop;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use function React\Async\async;
+use function React\Promise\all;
 
 class AwaitTest extends TestCase
 {
@@ -17,21 +18,21 @@ class AwaitTest extends TestCase
     {
         self::expectOutputString('abcd');
 
-        $deferred = new React\Promise\Deferred();
+        $deferred = new Deferred();
 
-        $promises[] = React\Async\async(function () use ($deferred, $await) {
+        $promises[] = async(function () use ($deferred, $await) {
             print 'a';
             $await($deferred->promise());
             print 'c';
         })();
 
-        $promises[] = React\Async\async(function () use ($deferred) {
+        $promises[] = async(function () use ($deferred) {
             print 'b';
             $deferred->resolve();
             print 'd';
         })();
 
-        $await(React\Promise\all($promises));
+        $await(all($promises));
     }
 
     /**

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -15,18 +15,18 @@ class AwaitTest extends TestCase
      */
     public function testExecutionOrder(callable $await)
     {
-        self::expectOutputString('acbd');
+        self::expectOutputString('abcd');
 
         $deferred = new React\Promise\Deferred();
 
         $promises[] = React\Async\async(function () use ($deferred, $await) {
             print 'a';
             $await($deferred->promise());
-            print 'b';
+            print 'c';
         })();
 
         $promises[] = React\Async\async(function () use ($deferred) {
-            print 'c';
+            print 'b';
             $deferred->resolve();
             print 'd';
         })();


### PR DESCRIPTION
This test currently has a different execution order in my adapter, so let's document the expected execution order.