### PR TITLE
[WIP] Cleanly `stop()` loop when awaiting promise without fiber

### DIFF
--- a/src/SimpleFiber.php
+++ b/src/SimpleFiber.php
@@ -63,7 +63,14 @@ final class SimpleFiber implements FiberInterface
                 });
             }
 
-            return (self::$scheduler->isStarted() ? self::$scheduler->resume() : self::$scheduler->start())();
+            $ret = (self::$scheduler->isStarted() ? self::$scheduler->resume() : self::$scheduler->start());
+            assert(is_callable($ret));
+
+            Loop::stop();
+            self::$scheduler->resume();
+            assert(self::$scheduler->isTerminated());
+
+            return $ret();
         }
 
         return \Fiber::suspend();


### PR DESCRIPTION
This changeset makes sure we cleanly `stop()` the loop when awaiting a promise without a fiber. This is especially important for test suites and other use cases where you would mix `await()` and `Loop::run()` calls. The `await()` call may currently suspend the `Loop::run()` call and leave it in an unpredictable state, possibly leaving socket resources or timers behind.

Builds on top of #15 and #32
Refs #27 and #50