### PR TITLE
[4.x] Template params can only have one argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ Loop::addTimer(2.0, function () use ($promise) {
 
 ### parallel()
 
-The `parallel(iterable<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `parallel(iterable<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
 like this:
 
 ```php
@@ -540,7 +540,7 @@ React\Async\parallel([
 
 ### series()
 
-The `series(iterable<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `series(iterable<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
 like this:
 
 ```php
@@ -582,7 +582,7 @@ React\Async\series([
 
 ### waterfall()
 
-The `waterfall(iterable<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<mixed,Exception>` function can be used
+The `waterfall(iterable<callable(mixed=):PromiseInterface<mixed>> $tasks): PromiseInterface<mixed>` function can be used
 like this:
 
 ```php

--- a/src/functions.php
+++ b/src/functions.php
@@ -652,8 +652,8 @@ function coroutine(callable $function, mixed ...$args): PromiseInterface
 }
 
 /**
- * @param iterable<callable():PromiseInterface<mixed,Exception>> $tasks
- * @return PromiseInterface<array<mixed>,Exception>
+ * @param iterable<callable():PromiseInterface<mixed>> $tasks
+ * @return PromiseInterface<array<mixed>>
  */
 function parallel(iterable $tasks): PromiseInterface
 {
@@ -711,8 +711,8 @@ function parallel(iterable $tasks): PromiseInterface
 }
 
 /**
- * @param iterable<callable():PromiseInterface<mixed,Exception>> $tasks
- * @return PromiseInterface<array<mixed>,Exception>
+ * @param iterable<callable():PromiseInterface<mixed>> $tasks
+ * @return PromiseInterface<array<mixed>>
  */
 function series(iterable $tasks): PromiseInterface
 {
@@ -762,8 +762,8 @@ function series(iterable $tasks): PromiseInterface
 }
 
 /**
- * @param iterable<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks
- * @return PromiseInterface<mixed,Exception>
+ * @param iterable<callable(mixed=):PromiseInterface<mixed>> $tasks
+ * @return PromiseInterface<mixed>
  */
 function waterfall(iterable $tasks): PromiseInterface
 {


### PR DESCRIPTION
The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223