### PR TITLE
[2.x] Template params can only have one argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ trigger at the earliest possible time in the future.
 
 ### parallel()
 
-The `parallel(array<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `parallel(array<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
 like this:
 
 ```php
@@ -203,7 +203,7 @@ React\Async\parallel([
 
 ### series()
 
-The `series(array<callable():PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<array<mixed>,Exception>` function can be used
+The `series(array<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
 like this:
 
 ```php
@@ -245,7 +245,7 @@ React\Async\series([
 
 ### waterfall()
 
-The `waterfall(array<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks): PromiseInterface<mixed,Exception>` function can be used
+The `waterfall(array<callable(mixed=):PromiseInterface<mixed>> $tasks): PromiseInterface<mixed>` function can be used
 like this:
 
 ```php

--- a/src/functions.php
+++ b/src/functions.php
@@ -179,8 +179,8 @@ function delay($seconds)
 }
 
 /**
- * @param array<callable():PromiseInterface<mixed,Exception>> $tasks
- * @return PromiseInterface<array<mixed>,Exception>
+ * @param array<callable():PromiseInterface<mixed>> $tasks
+ * @return PromiseInterface<array<mixed>>
  */
 function parallel(array $tasks)
 {
@@ -237,8 +237,8 @@ function parallel(array $tasks)
 }
 
 /**
- * @param array<callable():PromiseInterface<mixed,Exception>> $tasks
- * @return PromiseInterface<array<mixed>,Exception>
+ * @param array<callable():PromiseInterface<mixed>> $tasks
+ * @return PromiseInterface<array<mixed>>
  */
 function series(array $tasks)
 {
@@ -277,8 +277,8 @@ function series(array $tasks)
 }
 
 /**
- * @param array<callable(mixed=):PromiseInterface<mixed,Exception>> $tasks
- * @return PromiseInterface<mixed,Exception>
+ * @param array<callable(mixed=):PromiseInterface<mixed>> $tasks
+ * @return PromiseInterface<mixed>
  */
 function waterfall(array $tasks)
 {


### PR DESCRIPTION
The fact that a promise can also be rejected with a Throwable and/or Exception is implied and there is no need to also define that here.

Refs: https://github.com/reactphp/promise/pull/223
Backports #73 from `4.x` to `2.x` (see also #74 for same changes in `3.x`)