### PR TITLE
[3.x] Add PHPStan to test environment with `max` level

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
 /phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,25 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
+
+  PHPStan:
+    name: PHPStan (PHP ${{ matrix.php }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php:
+          - 8.2
+          - 8.1
+          - 8.0
+          - 7.4
+          - 7.3
+          - 7.2
+          - 7.1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - run: composer install
+      - run: vendor/bin/phpstan

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ To run the test suite, go to the project root and run:
 vendor/bin/phpunit
 ```
 
-On top of this, we use PHPStan on level 3 to ensure type safety across the project:
+On top of this, we use PHPStan on max level to ensure type safety across the project:
 
 ```bash
 vendor/bin/phpstan

--- a/README.md
+++ b/README.md
@@ -426,6 +426,12 @@ To run the test suite, go to the project root and run:
 vendor/bin/phpunit
 ```
 
+On top of this, we use PHPStan on level 3 to ensure type safety across the project:
+
+```bash
+vendor/bin/phpstan
+```
+
 ## License
 
 MIT, see [LICENSE file](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "react/promise": "^3.0 || ^2.8 || ^1.2.1"
     },
     "require-dev": {
+        "phpstan/phpstan": "1.10.18 || 1.4.10",
         "phpunit/phpunit": "^9.5 || ^7.5"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: max
 
     paths:
         - src/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+parameters:
+    level: 3
+
+    paths:
+        - src/
+        - tests/
+
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        # ignore generic usage like `PromiseInterface<T>` until fixed upstream
+        - '/^PHPDoc .* contains generic type React\\Promise\\PromiseInterface<.+> but interface React\\Promise\\PromiseInterface is not generic\.$/'

--- a/src/functions.php
+++ b/src/functions.php
@@ -294,7 +294,7 @@ function delay(float $seconds): void
  * });
  * ```
  *
- * @param callable(...$args):\Generator<mixed,PromiseInterface,mixed,mixed> $function
+ * @param callable(mixed ...$args):\Generator<mixed,PromiseInterface,mixed,mixed> $function
  * @param mixed ...$args Optional list of additional arguments that will be passed to the given `$function` as is
  * @return PromiseInterface<mixed>
  * @since 3.0.0
@@ -437,9 +437,9 @@ function series(iterable $tasks): PromiseInterface
         assert($tasks instanceof \Iterator);
     }
 
-    /** @var callable():void $next */
     $taskCallback = function ($result) use (&$results, &$next) {
         $results[] = $result;
+        assert($next instanceof \Closure);
         $next();
     };
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -56,6 +56,8 @@ function await(PromiseInterface $promise)
     $resolved = null;
     $exception = null;
     $rejected = false;
+
+    /** @var bool $loopStarted */
     $loopStarted = false;
 
     $promise->then(
@@ -294,7 +296,7 @@ function delay(float $seconds): void
  * });
  * ```
  *
- * @param callable(mixed ...$args):\Generator<mixed,PromiseInterface,mixed,mixed> $function
+ * @param callable(mixed ...$args):(\Generator<mixed,PromiseInterface,mixed,mixed>|mixed) $function
  * @param mixed ...$args Optional list of additional arguments that will be passed to the given `$function` as is
  * @return PromiseInterface<mixed>
  * @since 3.0.0
@@ -313,6 +315,7 @@ function coroutine(callable $function, ...$args): PromiseInterface
 
     $promise = null;
     $deferred = new Deferred(function () use (&$promise) {
+        /** @var ?PromiseInterface $promise */
         if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
             $promise->cancel();
         }
@@ -333,6 +336,7 @@ function coroutine(callable $function, ...$args): PromiseInterface
             return;
         }
 
+        /** @var mixed $promise */
         $promise = $generator->current();
         if (!$promise instanceof PromiseInterface) {
             $next = null;
@@ -342,6 +346,7 @@ function coroutine(callable $function, ...$args): PromiseInterface
             return;
         }
 
+        assert($next instanceof \Closure);
         $promise->then(function ($value) use ($generator, $next) {
             $generator->send($value);
             $next();
@@ -364,6 +369,7 @@ function coroutine(callable $function, ...$args): PromiseInterface
  */
 function parallel(iterable $tasks): PromiseInterface
 {
+    /** @var array<int,PromiseInterface> $pending */
     $pending = [];
     $deferred = new Deferred(function () use (&$pending) {
         foreach ($pending as $promise) {
@@ -425,6 +431,7 @@ function series(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
+        /** @var ?PromiseInterface $pending */
         if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
             $pending->cancel();
         }
@@ -439,7 +446,7 @@ function series(iterable $tasks): PromiseInterface
 
     $taskCallback = function ($result) use (&$results, &$next) {
         $results[] = $result;
-        assert($next instanceof \Closure);
+        /** @var \Closure $next */
         $next();
     };
 
@@ -453,9 +460,11 @@ function series(iterable $tasks): PromiseInterface
             $task = $tasks->current();
             $tasks->next();
         } else {
+            assert(\is_array($tasks));
             $task = \array_shift($tasks);
         }
 
+        assert(\is_callable($task));
         $promise = \call_user_func($task);
         assert($promise instanceof PromiseInterface);
         $pending = $promise;
@@ -469,13 +478,14 @@ function series(iterable $tasks): PromiseInterface
 }
 
 /**
- * @param iterable<callable(mixed=):PromiseInterface<mixed>> $tasks
+ * @param iterable<(callable():PromiseInterface<mixed>)|(callable(mixed):PromiseInterface<mixed>)> $tasks
  * @return PromiseInterface<mixed>
  */
 function waterfall(iterable $tasks): PromiseInterface
 {
     $pending = null;
     $deferred = new Deferred(function () use (&$pending) {
+        /** @var ?PromiseInterface $pending */
         if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
             $pending->cancel();
         }
@@ -498,9 +508,11 @@ function waterfall(iterable $tasks): PromiseInterface
             $task = $tasks->current();
             $tasks->next();
         } else {
+            assert(\is_array($tasks));
             $task = \array_shift($tasks);
         }
 
+        assert(\is_callable($task));
         $promise = \call_user_func_array($task, func_get_args());
         assert($promise instanceof PromiseInterface);
         $pending = $promise;

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -8,7 +8,7 @@ use React\Promise\Promise;
 
 class AwaitTest extends TestCase
 {
-    public function testAwaitThrowsExceptionWhenPromiseIsRejectedWithException()
+    public function testAwaitThrowsExceptionWhenPromiseIsRejectedWithException(): void
     {
         $promise = new Promise(function () {
             throw new \Exception('test');
@@ -19,7 +19,7 @@ class AwaitTest extends TestCase
         React\Async\await($promise);
     }
 
-    public function testAwaitThrowsUnexpectedValueExceptionWhenPromiseIsRejectedWithFalse()
+    public function testAwaitThrowsUnexpectedValueExceptionWhenPromiseIsRejectedWithFalse(): void
     {
         if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
             $this->markTestSkipped('Promises must be rejected with a \Throwable instance since Promise v3');
@@ -34,7 +34,7 @@ class AwaitTest extends TestCase
         React\Async\await($promise);
     }
 
-    public function testAwaitThrowsUnexpectedValueExceptionWhenPromiseIsRejectedWithNull()
+    public function testAwaitThrowsUnexpectedValueExceptionWhenPromiseIsRejectedWithNull(): void
     {
         if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
             $this->markTestSkipped('Promises must be rejected with a \Throwable instance since Promise v3');
@@ -49,7 +49,7 @@ class AwaitTest extends TestCase
         React\Async\await($promise);
     }
 
-    public function testAwaitThrowsErrorWhenPromiseIsRejectedWithError()
+    public function testAwaitThrowsErrorWhenPromiseIsRejectedWithError(): void
     {
         $promise = new Promise(function ($_, $reject) {
             throw new \Error('Test', 42);
@@ -61,7 +61,7 @@ class AwaitTest extends TestCase
         React\Async\await($promise);
     }
 
-    public function testAwaitReturnsValueWhenPromiseIsFullfilled()
+    public function testAwaitReturnsValueWhenPromiseIsFullfilled(): void
     {
         $promise = new Promise(function ($resolve) {
             $resolve(42);
@@ -70,7 +70,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(42, React\Async\await($promise));
     }
 
-    public function testAwaitReturnsValueWhenPromiseIsFulfilledEvenWhenOtherTimerStopsLoop()
+    public function testAwaitReturnsValueWhenPromiseIsFulfilledEvenWhenOtherTimerStopsLoop(): void
     {
         $promise = new Promise(function ($resolve) {
             Loop::addTimer(0.02, function () use ($resolve) {
@@ -84,7 +84,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(2, React\Async\await($promise));
     }
 
-    public function testAwaitWithAlreadyFulfilledPromiseWillReturnWithoutRunningLoop()
+    public function testAwaitWithAlreadyFulfilledPromiseWillReturnWithoutRunningLoop(): void
     {
         $now = true;
 
@@ -100,7 +100,7 @@ class AwaitTest extends TestCase
         $this->assertTrue($now);
     }
 
-    public function testAwaitWithAlreadyFulfilledPromiseWillReturnWithoutStoppingLoop()
+    public function testAwaitWithAlreadyFulfilledPromiseWillReturnWithoutStoppingLoop(): void
     {
         $ticks = 0;
 
@@ -128,7 +128,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(2, $ticks);
     }
 
-    public function testAwaitWithPendingPromiseThatWillResolveWillStopLoopBeforeLastTimerFinishes()
+    public function testAwaitWithPendingPromiseThatWillResolveWillStopLoopBeforeLastTimerFinishes(): void
     {
         $promise = new Promise(function ($resolve) {
             Loop::addTimer(0.02, function () use ($resolve) {
@@ -159,7 +159,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(1, $ticks);
     }
 
-    public function testAwaitWithAlreadyRejectedPromiseWillReturnWithoutStoppingLoop()
+    public function testAwaitWithAlreadyRejectedPromiseWillReturnWithoutStoppingLoop(): void
     {
         $ticks = 0;
 
@@ -191,7 +191,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(2, $ticks);
     }
 
-    public function testAwaitWithPendingPromiseThatWillRejectWillStopLoopBeforeLastTimerFinishes()
+    public function testAwaitWithPendingPromiseThatWillRejectWillStopLoopBeforeLastTimerFinishes(): void
     {
         $promise = new Promise(function ($_, $reject) {
             Loop::addTimer(0.02, function () use (&$reject) {
@@ -227,7 +227,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(1, $ticks);
     }
 
-    public function testAwaitShouldNotCreateAnyGarbageReferencesForResolvedPromise()
+    public function testAwaitShouldNotCreateAnyGarbageReferencesForResolvedPromise(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
@@ -244,7 +244,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    public function testAwaitShouldNotCreateAnyGarbageReferencesForRejectedPromise()
+    public function testAwaitShouldNotCreateAnyGarbageReferencesForRejectedPromise(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
@@ -265,7 +265,7 @@ class AwaitTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    public function testAwaitShouldNotCreateAnyGarbageReferencesForPromiseRejectedWithNullValue()
+    public function testAwaitShouldNotCreateAnyGarbageReferencesForPromiseRejectedWithNullValue(): void
     {
         if (!interface_exists('React\Promise\CancellablePromiseInterface')) {
             $this->markTestSkipped('Promises must be rejected with a \Throwable instance since Promise v3');

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -114,6 +114,7 @@ class CoroutineTest extends TestCase
             });
         });
 
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
 
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Operation cancelled')));
@@ -131,6 +132,7 @@ class CoroutineTest extends TestCase
             }
         });
 
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
 
         $promise->then($this->expectCallableOnceWith(42));
@@ -150,6 +152,7 @@ class CoroutineTest extends TestCase
             }
         });
 
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
 
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
@@ -209,6 +212,7 @@ class CoroutineTest extends TestCase
             });
         });
 
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
         unset($promise);
 

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -9,7 +9,7 @@ use function React\Promise\resolve;
 
 class CoroutineTest extends TestCase
 {
-    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsWithoutGenerator()
+    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsWithoutGenerator(): void
     {
         $promise = coroutine(function () {
             return 42;
@@ -18,10 +18,10 @@ class CoroutineTest extends TestCase
         $promise->then($this->expectCallableOnceWith(42));
     }
 
-    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsImmediately()
+    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsImmediately(): void
     {
         $promise = coroutine(function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             return 42;
@@ -30,7 +30,7 @@ class CoroutineTest extends TestCase
         $promise->then($this->expectCallableOnceWith(42));
     }
 
-    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsAfterYieldingPromise()
+    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsAfterYieldingPromise(): void
     {
         $promise = coroutine(function () {
             $value = yield resolve(42);
@@ -40,7 +40,7 @@ class CoroutineTest extends TestCase
         $promise->then($this->expectCallableOnceWith(42));
     }
 
-    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsWithoutGenerator()
+    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsWithoutGenerator(): void
     {
         $promise = coroutine(function () {
             throw new \RuntimeException('Foo');
@@ -49,10 +49,10 @@ class CoroutineTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Foo')));
     }
 
-    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsImmediately()
+    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsImmediately(): void
     {
         $promise = coroutine(function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             throw new \RuntimeException('Foo');
@@ -61,7 +61,7 @@ class CoroutineTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Foo')));
     }
 
-    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsAfterYieldingPromise()
+    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsAfterYieldingPromise(): void
     {
         $promise = coroutine(function () {
             $reason = yield resolve('Foo');
@@ -71,7 +71,7 @@ class CoroutineTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Foo')));
     }
 
-    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsAfterYieldingRejectedPromise()
+    public function testCoroutineReturnsRejectedPromiseIfFunctionThrowsAfterYieldingRejectedPromise(): void
     {
         $promise = coroutine(function () {
             try {
@@ -84,7 +84,7 @@ class CoroutineTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Foo')));
     }
 
-    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsAfterYieldingRejectedPromise()
+    public function testCoroutineReturnsFulfilledPromiseIfFunctionReturnsAfterYieldingRejectedPromise(): void
     {
         $promise = coroutine(function () {
             try {
@@ -97,7 +97,7 @@ class CoroutineTest extends TestCase
         $promise->then($this->expectCallableOnceWith(42));
     }
 
-    public function testCoroutineReturnsRejectedPromiseIfFunctionYieldsInvalidValue()
+    public function testCoroutineReturnsRejectedPromiseIfFunctionYieldsInvalidValue(): void
     {
         $promise = coroutine(function () {
             yield 42;
@@ -106,7 +106,7 @@ class CoroutineTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \UnexpectedValueException('Expected coroutine to yield React\Promise\PromiseInterface, but got integer')));
     }
 
-    public function testCancelCoroutineWillReturnRejectedPromiseWhenCancellingPendingPromiseRejects()
+    public function testCancelCoroutineWillReturnRejectedPromiseWhenCancellingPendingPromiseRejects(): void
     {
         $promise = coroutine(function () {
             yield new Promise(function () { }, function () {
@@ -120,7 +120,7 @@ class CoroutineTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWith(new \RuntimeException('Operation cancelled')));
     }
 
-    public function testCancelCoroutineWillReturnFulfilledPromiseWhenCancellingPendingPromiseRejectsInsideCatchThatReturnsValue()
+    public function testCancelCoroutineWillReturnFulfilledPromiseWhenCancellingPendingPromiseRejectsInsideCatchThatReturnsValue(): void
     {
         $promise = coroutine(function () {
             try {
@@ -138,7 +138,7 @@ class CoroutineTest extends TestCase
         $promise->then($this->expectCallableOnceWith(42));
     }
 
-    public function testCancelCoroutineWillReturnPendigPromiseWhenCancellingFirstPromiseRejectsInsideCatchThatYieldsSecondPromise()
+    public function testCancelCoroutineWillReturnPendigPromiseWhenCancellingFirstPromiseRejectsInsideCatchThatYieldsSecondPromise(): void
     {
         $promise = coroutine(function () {
             try {
@@ -158,7 +158,7 @@ class CoroutineTest extends TestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableNever());
     }
 
-    public function testCoroutineShouldNotCreateAnyGarbageReferencesWhenGeneratorReturns()
+    public function testCoroutineShouldNotCreateAnyGarbageReferencesWhenGeneratorReturns(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
@@ -168,7 +168,7 @@ class CoroutineTest extends TestCase
         gc_collect_cycles();
 
         $promise = coroutine(function () {
-            if (false) {
+            if (false) { // @phpstan-ignore-line
                 yield;
             }
             return 42;
@@ -179,7 +179,7 @@ class CoroutineTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    public function testCoroutineShouldNotCreateAnyGarbageReferencesForPromiseRejectedWithExceptionImmediately()
+    public function testCoroutineShouldNotCreateAnyGarbageReferencesForPromiseRejectedWithExceptionImmediately(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
@@ -198,7 +198,7 @@ class CoroutineTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    public function testCoroutineShouldNotCreateAnyGarbageReferencesForPromiseRejectedWithExceptionOnCancellation()
+    public function testCoroutineShouldNotCreateAnyGarbageReferencesForPromiseRejectedWithExceptionOnCancellation(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
@@ -219,7 +219,7 @@ class CoroutineTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    public function testCoroutineShouldNotCreateAnyGarbageReferencesWhenGeneratorThrowsBeforeFirstYield()
+    public function testCoroutineShouldNotCreateAnyGarbageReferencesWhenGeneratorThrowsBeforeFirstYield(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');
@@ -229,7 +229,7 @@ class CoroutineTest extends TestCase
 
         $promise = coroutine(function () {
             throw new \RuntimeException('Failed', 42);
-            yield;
+            yield; // @phpstan-ignore-line
         });
 
         unset($promise);
@@ -237,7 +237,7 @@ class CoroutineTest extends TestCase
         $this->assertEquals(0, gc_collect_cycles());
     }
 
-    public function testCoroutineShouldNotCreateAnyGarbageReferencesWhenGeneratorYieldsInvalidValue()
+    public function testCoroutineShouldNotCreateAnyGarbageReferencesWhenGeneratorYieldsInvalidValue(): void
     {
         if (class_exists('React\Promise\When')) {
             $this->markTestSkipped('Not supported on legacy Promise v1 API');

--- a/tests/DelayTest.php
+++ b/tests/DelayTest.php
@@ -8,7 +8,7 @@ use function React\Async\delay;
 
 class DelayTest extends TestCase
 {
-    public function testDelayBlocksForGivenPeriod()
+    public function testDelayBlocksForGivenPeriod(): void
     {
         $time = microtime(true);
         delay(0.02);
@@ -17,7 +17,7 @@ class DelayTest extends TestCase
         $this->assertEqualsWithDelta(0.02, $time, 0.01);
     }
 
-    public function testDelaySmallPeriodBlocksForCloseToZeroSeconds()
+    public function testDelaySmallPeriodBlocksForCloseToZeroSeconds(): void
     {
         $time = microtime(true);
         delay(0.000001);
@@ -26,7 +26,7 @@ class DelayTest extends TestCase
         $this->assertLessThan(0.01, $time);
     }
 
-    public function testDelayNegativePeriodBlocksForCloseToZeroSeconds()
+    public function testDelayNegativePeriodBlocksForCloseToZeroSeconds(): void
     {
         $time = microtime(true);
         delay(-1);
@@ -35,7 +35,7 @@ class DelayTest extends TestCase
         $this->assertLessThan(0.01, $time);
     }
 
-    public function testDelayRunsOtherEventsWhileWaiting()
+    public function testDelayRunsOtherEventsWhileWaiting(): void
     {
         $buffer = 'a';
         Loop::addTimer(0.001, function () use (&$buffer) {

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -6,10 +6,11 @@ use React;
 use React\EventLoop\Loop;
 use React\Promise\Promise;
 use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class ParallelTest extends TestCase
 {
-    public function testParallelWithoutTasks()
+    public function testParallelWithoutTasks(): void
     {
         $tasks = array();
 
@@ -18,11 +19,11 @@ class ParallelTest extends TestCase
         $promise->then($this->expectCallableOnceWith(array()));
     }
 
-    public function testParallelWithoutTasksFromEmptyGeneratorResolvesWithEmptyArray()
+    public function testParallelWithoutTasksFromEmptyGeneratorResolvesWithEmptyArray(): void
     {
         $tasks = (function () {
-            if (false) {
-                yield;
+            if (false) { // @phpstan-ignore-line
+                yield function () { return resolve(null); };
             }
         })();
 
@@ -31,7 +32,7 @@ class ParallelTest extends TestCase
         $promise->then($this->expectCallableOnceWith([]));
     }
 
-    public function testParallelWithTasks()
+    public function testParallelWithTasks(): void
     {
         $tasks = array(
             function () {
@@ -63,7 +64,7 @@ class ParallelTest extends TestCase
         $timer->assertInRange(0.1, 0.2);
     }
 
-    public function testParallelWithTasksFromGeneratorResolvesWithArrayOfFulfillmentValues()
+    public function testParallelWithTasksFromGeneratorResolvesWithArrayOfFulfillmentValues(): void
     {
         $tasks = (function () {
             yield function () {
@@ -95,7 +96,7 @@ class ParallelTest extends TestCase
         $timer->assertInRange(0.1, 0.2);
     }
 
-    public function testParallelWithErrorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    public function testParallelWithErrorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks(): void
     {
         $called = 0;
 
@@ -127,12 +128,12 @@ class ParallelTest extends TestCase
         $this->assertSame(2, $called);
     }
 
-    public function testParallelWithErrorFromInfiniteGeneratorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    public function testParallelWithErrorFromInfiniteGeneratorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks(): void
     {
         $called = 0;
 
         $tasks = (function () use (&$called) {
-            while (true) {
+            while (true) { // @phpstan-ignore-line
                 yield function () use (&$called) {
                     return reject(new \RuntimeException('Rejected ' . ++$called));
                 };
@@ -146,7 +147,7 @@ class ParallelTest extends TestCase
         $this->assertSame(1, $called);
     }
 
-    public function testParallelWithErrorWillCancelPendingPromises()
+    public function testParallelWithErrorWillCancelPendingPromises(): void
     {
         $cancelled = 0;
 
@@ -175,7 +176,7 @@ class ParallelTest extends TestCase
         $this->assertSame(1, $cancelled);
     }
 
-    public function testParallelWillCancelPendingPromisesWhenCallingCancelOnResultingPromise()
+    public function testParallelWillCancelPendingPromisesWhenCallingCancelOnResultingPromise(): void
     {
         $cancelled = 0;
 
@@ -199,7 +200,7 @@ class ParallelTest extends TestCase
         $this->assertSame(2, $cancelled);
     }
 
-    public function testParallelWithDelayedErrorReturnsPromiseRejectedWithExceptionFromTask()
+    public function testParallelWithDelayedErrorReturnsPromiseRejectedWithExceptionFromTask(): void
     {
         $called = 0;
 

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -193,6 +193,7 @@ class ParallelTest extends TestCase
         );
 
         $promise = React\Async\parallel($tasks);
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
 
         $this->assertSame(2, $cancelled);

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -185,6 +185,7 @@ class SeriesTest extends TestCase
         );
 
         $promise = React\Async\series($tasks);
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
 
         $this->assertSame(1, $cancelled);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,45 +3,43 @@
 namespace React\Tests\Async;
 
 use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    protected function expectCallableOnce()
+    protected function expectCallableOnce(): callable
     {
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke');
+        $mock->expects($this->once())->method('__invoke');
+        assert(is_callable($mock));
 
         return $mock;
     }
 
-    protected function expectCallableOnceWith($value)
+    /** @param mixed $value */
+    protected function expectCallableOnceWith($value): callable
     {
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($value);
+        $mock->expects($this->once())->method('__invoke')->with($value);
+        assert(is_callable($mock));
 
         return $mock;
     }
 
-    protected function expectCallableNever()
+    protected function expectCallableNever(): callable
     {
         $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->never())
-            ->method('__invoke');
+        $mock->expects($this->never())->method('__invoke');
+        assert(is_callable($mock));
 
         return $mock;
     }
 
-    protected function createCallableMock()
+    protected function createCallableMock(): MockObject
     {
         if (method_exists(MockBuilder::class, 'addMethods')) {
-            // PHPUnit 9+
+            // @phpstan-ignore-next-line PHPUnit 9+
             return $this->getMockBuilder(\stdClass::class)->addMethods(['__invoke'])->getMock();
         } else {
             // PHPUnit < 9

--- a/tests/Timer.php
+++ b/tests/Timer.php
@@ -4,8 +4,13 @@ namespace React\Tests\Async;
 
 class Timer
 {
+    /** @var TestCase */
     private $testCase;
+
+    /** @var float */
     private $start;
+
+    /** @var float */
     private $stop;
 
     public function __construct(TestCase $testCase)
@@ -13,32 +18,32 @@ class Timer
         $this->testCase = $testCase;
     }
 
-    public function start()
+    public function start(): void
     {
         $this->start = microtime(true);
     }
 
-    public function stop()
+    public function stop(): void
     {
         $this->stop = microtime(true);
     }
 
-    public function getInterval()
+    public function getInterval(): float
     {
         return $this->stop - $this->start;
     }
 
-    public function assertLessThan($milliseconds)
+    public function assertLessThan(float $milliseconds): void
     {
         $this->testCase->assertLessThan($milliseconds, $this->getInterval());
     }
 
-    public function assertGreaterThan($milliseconds)
+    public function assertGreaterThan(float $milliseconds): void
     {
         $this->testCase->assertGreaterThan($milliseconds, $this->getInterval());
     }
 
-    public function assertInRange($minMs, $maxMs)
+    public function assertInRange(float $minMs, float $maxMs): void
     {
         $this->assertGreaterThan($minMs);
         $this->assertLessThan($maxMs);

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -199,6 +199,7 @@ class WaterfallTest extends TestCase
         );
 
         $promise = React\Async\waterfall($tasks);
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
 
         $this->assertSame(1, $cancelled);

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -6,10 +6,11 @@ use React;
 use React\EventLoop\Loop;
 use React\Promise\Promise;
 use function React\Promise\reject;
+use function React\Promise\resolve;
 
 class WaterfallTest extends TestCase
 {
-    public function testWaterfallWithoutTasks()
+    public function testWaterfallWithoutTasks(): void
     {
         $tasks = array();
 
@@ -18,11 +19,11 @@ class WaterfallTest extends TestCase
         $promise->then($this->expectCallableOnceWith(null));
     }
 
-    public function testWaterfallWithoutTasksFromEmptyGeneratorResolvesWithNull()
+    public function testWaterfallWithoutTasksFromEmptyGeneratorResolvesWithNull(): void
     {
         $tasks = (function () {
-            if (false) {
-                yield;
+            if (false) { // @phpstan-ignore-line
+                yield function () { return resolve(null); };
             }
         })();
 
@@ -31,7 +32,7 @@ class WaterfallTest extends TestCase
         $promise->then($this->expectCallableOnceWith(null));
     }
 
-    public function testWaterfallWithTasks()
+    public function testWaterfallWithTasks(): void
     {
         $tasks = array(
             function ($foo = 'foo') {
@@ -70,7 +71,7 @@ class WaterfallTest extends TestCase
         $timer->assertInRange(0.15, 0.30);
     }
 
-    public function testWaterfallWithTasksFromGeneratorResolvesWithFinalFulfillmentValue()
+    public function testWaterfallWithTasksFromGeneratorResolvesWithFinalFulfillmentValue(): void
     {
         $tasks = (function () {
             yield function ($foo = 'foo') {
@@ -109,7 +110,7 @@ class WaterfallTest extends TestCase
         $timer->assertInRange(0.15, 0.30);
     }
 
-    public function testWaterfallWithError()
+    public function testWaterfallWithError(): void
     {
         $called = 0;
 
@@ -140,12 +141,12 @@ class WaterfallTest extends TestCase
         $this->assertSame(1, $called);
     }
 
-    public function testWaterfallWithErrorFromInfiniteGeneratorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    public function testWaterfallWithErrorFromInfiniteGeneratorReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks(): void
     {
         $called = 0;
 
         $tasks = (function () use (&$called) {
-            while (true) {
+            while (true) { // @phpstan-ignore-line
                 yield function () use (&$called) {
                     return reject(new \RuntimeException('Rejected ' . ++$called));
                 };
@@ -159,14 +160,15 @@ class WaterfallTest extends TestCase
         $this->assertSame(1, $called);
     }
 
-    public function testWaterfallWithErrorFromInfiniteIteratorAggregateReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks()
+    public function testWaterfallWithErrorFromInfiniteIteratorAggregateReturnsPromiseRejectedWithExceptionFromTaskAndStopsCallingAdditionalTasks(): void
     {
         $tasks = new class() implements \IteratorAggregate {
+            /** @var int */
             public $called = 0;
 
             public function getIterator(): \Iterator
             {
-                while (true) {
+                while (true) { // @phpstan-ignore-line
                     yield function () {
                         return reject(new \RuntimeException('Rejected ' . ++$this->called));
                     };
@@ -181,7 +183,7 @@ class WaterfallTest extends TestCase
         $this->assertSame(1, $tasks->called);
     }
 
-    public function testWaterfallWillCancelFirstPendingPromiseWhenCallingCancelOnResultingPromise()
+    public function testWaterfallWillCancelFirstPendingPromiseWhenCallingCancelOnResultingPromise(): void
     {
         $cancelled = 0;
 


### PR DESCRIPTION
This changeset backports #76 from `4.x` to `3.x` to add PHPStan on `max` level to the test environment for all supported PHP versions. Most changes have been applied as-is, but v3 requires a number of workarounds to support legacy PHP and PHPUnit versions.

If this PR is merged, we could backport most of the changes from v3 to v2. The changes are somewhat similar across all versions, but v2 still supports legacy PHP, so we would have to resort to type definitions in docblocks instead of native PHP types. Let's continue this discussion outside of this PR.

Builds on top of #76
See also https://github.com/orgs/reactphp/discussions/469