### PR TITLE
[3.x] Update test suite to avoid unhandled promise rejections

### DIFF
--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -193,6 +193,8 @@ class CoroutineTest extends TestCase
             });
         });
 
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertEquals(0, gc_collect_cycles());
@@ -232,6 +234,8 @@ class CoroutineTest extends TestCase
             yield; // @phpstan-ignore-line
         });
 
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
+
         unset($promise);
 
         $this->assertEquals(0, gc_collect_cycles());
@@ -248,6 +252,8 @@ class CoroutineTest extends TestCase
         $promise = coroutine(function () {
             yield 42;
         });
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
 
         unset($promise);
 


### PR DESCRIPTION
This changeset backports #79 from `4.x` to `3.x`. There is no need to backport to `2.x` as this only affects the `coroutine()` function that is only available in v3+ (#12).

~~Marking this as WIP until the upstream component has been released. In the meantime, this uses a temporary development branch.~~

Builds on top of https://github.com/reactphp/promise/pull/248, #77 and #47