### PR TITLE
[3.x] Add template annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
           - 7.4
           - 7.3
           - 7.2
-          - 7.1
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Async\await(…);
 
 ### await()
 
-The `await(PromiseInterface $promise): mixed` function can be used to
+The `await(PromiseInterface<T> $promise): T` function can be used to
 block waiting for the given `$promise` to be fulfilled.
 
 ```php
@@ -94,7 +94,7 @@ try {
 
 ### coroutine()
 
-The `coroutine(callable $function, mixed ...$args): PromiseInterface<mixed>` function can be used to
+The `coroutine(callable(mixed ...$args):(\Generator|PromiseInterface<T>|T) $function, mixed ...$args): PromiseInterface<T>` function can be used to
 execute a Generator-based coroutine to "await" promises.
 
 ```php
@@ -277,7 +277,7 @@ trigger at the earliest possible time in the future.
 
 ### parallel()
 
-The `parallel(iterable<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
+The `parallel(iterable<callable():PromiseInterface<T>> $tasks): PromiseInterface<array<T>>` function can be used
 like this:
 
 ```php
@@ -319,7 +319,7 @@ React\Async\parallel([
 
 ### series()
 
-The `series(iterable<callable():PromiseInterface<mixed>> $tasks): PromiseInterface<array<mixed>>` function can be used
+The `series(iterable<callable():PromiseInterface<T>> $tasks): PromiseInterface<array<T>>` function can be used
 like this:
 
 ```php
@@ -361,7 +361,7 @@ React\Async\series([
 
 ### waterfall()
 
-The `waterfall(iterable<callable(mixed=):PromiseInterface<mixed>> $tasks): PromiseInterface<mixed>` function can be used
+The `waterfall(iterable<callable(mixed=):PromiseInterface<T>> $tasks): PromiseInterface<T>` function can be used
 like this:
 
 ```php

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -22,7 +22,7 @@ class CoroutineTest extends TestCase
     {
         $promise = coroutine(function () {
             if (false) { // @phpstan-ignore-line
-                yield;
+                yield resolve(null);
             }
             return 42;
         });
@@ -53,7 +53,7 @@ class CoroutineTest extends TestCase
     {
         $promise = coroutine(function () {
             if (false) { // @phpstan-ignore-line
-                yield;
+                yield resolve(null);
             }
             throw new \RuntimeException('Foo');
         });
@@ -99,7 +99,7 @@ class CoroutineTest extends TestCase
 
     public function testCoroutineReturnsRejectedPromiseIfFunctionYieldsInvalidValue(): void
     {
-        $promise = coroutine(function () {
+        $promise = coroutine(function () { // @phpstan-ignore-line
             yield 42;
         });
 
@@ -169,7 +169,7 @@ class CoroutineTest extends TestCase
 
         $promise = coroutine(function () {
             if (false) { // @phpstan-ignore-line
-                yield;
+                yield resolve(null);
             }
             return 42;
         });
@@ -249,7 +249,7 @@ class CoroutineTest extends TestCase
 
         gc_collect_cycles();
 
-        $promise = coroutine(function () {
+        $promise = coroutine(function () { // @phpstan-ignore-line
             yield 42;
         });
 

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -12,6 +12,9 @@ class ParallelTest extends TestCase
 {
     public function testParallelWithoutTasks(): void
     {
+        /**
+         * @var array<callable(): React\Promise\PromiseInterface<mixed>> $tasks
+         */
         $tasks = array();
 
         $promise = React\Async\parallel($tasks);

--- a/tests/SeriesTest.php
+++ b/tests/SeriesTest.php
@@ -12,6 +12,9 @@ class SeriesTest extends TestCase
 {
     public function testSeriesWithoutTasks(): void
     {
+        /**
+         * @var array<callable(): React\Promise\PromiseInterface<mixed>> $tasks
+         */
         $tasks = array();
 
         $promise = React\Async\series($tasks);
@@ -152,6 +155,9 @@ class SeriesTest extends TestCase
             /** @var int */
             public $called = 0;
 
+            /**
+             * @return \Iterator<callable(): React\Promise\PromiseInterface<mixed>>
+             */
             public function getIterator(): \Iterator
             {
                 while (true) { // @phpstan-ignore-line

--- a/tests/WaterfallTest.php
+++ b/tests/WaterfallTest.php
@@ -12,6 +12,9 @@ class WaterfallTest extends TestCase
 {
     public function testWaterfallWithoutTasks(): void
     {
+        /**
+         * @var array<callable(): React\Promise\PromiseInterface<mixed>> $tasks
+         */
         $tasks = array();
 
         $promise = React\Async\waterfall($tasks);
@@ -166,6 +169,9 @@ class WaterfallTest extends TestCase
             /** @var int */
             public $called = 0;
 
+            /**
+             * @return \Iterator<callable(): React\Promise\PromiseInterface<mixed>>
+             */
             public function getIterator(): \Iterator
             {
                 while (true) { // @phpstan-ignore-line

--- a/tests/types/await.php
+++ b/tests/types/await.php
@@ -1,0 +1,18 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Promise\resolve;
+
+assertType('bool', await(resolve(true)));
+
+final class AwaitExampleUser
+{
+    public string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}
+
+assertType('string', await(resolve(new AwaitExampleUser('WyriHaximus')))->name);

--- a/tests/types/coroutine.php
+++ b/tests/types/coroutine.php
@@ -1,0 +1,60 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\coroutine;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    return true;
+}));
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    return resolve(true);
+}));
+
+// assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+//     return (yield resolve(true));
+// }));
+
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function () {
+//     $bool = yield resolve(true);
+//     assertType('bool', $bool);
+
+    return time();
+}));
+
+// assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+//     $bool = yield resolve(true);
+//     assertType('bool', $bool);
+
+//     return $bool;
+// }));
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    yield resolve(time());
+
+    return true;
+}));
+
+assertType('React\Promise\PromiseInterface<bool>', coroutine(static function () {
+    for ($i = 0; $i <= 10; $i++) {
+        yield resolve($i);
+    }
+
+    return true;
+}));
+
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function (int $a): int { return $a; }, 42));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function (int $a, int $b): int { return $a + $b; }, 10, 32));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function (int $a, int $b, int $c): int { return $a + $b + $c; }, 10, 22, 10));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function (int $a, int $b, int $c, int $d): int { return $a + $b + $c + $d; }, 10, 22, 5, 5));
+assertType('React\Promise\PromiseInterface<int>', coroutine(static function (int $a, int $b, int $c, int $d, int $e): int { return $a + $b + $c + $d + $e; }, 10, 12, 10, 5, 5));
+
+assertType('bool', await(coroutine(static function () {
+    return true;
+})));
+
+// assertType('bool', await(coroutine(static function () {
+//     return (yield resolve(true));
+// })));

--- a/tests/types/parallel.php
+++ b/tests/types/parallel.php
@@ -1,0 +1,33 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\parallel;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<array>', parallel([]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', parallel([
+    static function (): PromiseInterface { return resolve(true); },
+    static function (): PromiseInterface { return resolve(time()); },
+    static function (): PromiseInterface { return resolve(microtime(true)); },
+]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', parallel([
+    static function (): bool { return true; },
+    static function (): int { return time(); },
+    static function (): float { return microtime(true); },
+]));
+
+assertType('array<bool|float|int>', await(parallel([
+    static function (): PromiseInterface { return resolve(true); },
+    static function (): PromiseInterface { return resolve(time()); },
+    static function (): PromiseInterface { return resolve(microtime(true)); },
+])));
+
+assertType('array<bool|float|int>', await(parallel([
+    static function (): bool { return true; },
+    static function (): int { return time(); },
+    static function (): float { return microtime(true); },
+])));

--- a/tests/types/series.php
+++ b/tests/types/series.php
@@ -1,0 +1,33 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\series;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<array>', series([]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', series([
+    static function (): PromiseInterface { return resolve(true); },
+    static function (): PromiseInterface { return resolve(time()); },
+    static function (): PromiseInterface { return resolve(microtime(true)); },
+]));
+
+assertType('React\Promise\PromiseInterface<array<bool|float|int>>', series([
+    static function (): bool { return true; },
+    static function (): int { return time(); },
+    static function (): float { return microtime(true); },
+]));
+
+assertType('array<bool|float|int>', await(series([
+    static function (): PromiseInterface { return resolve(true); },
+    static function (): PromiseInterface { return resolve(time()); },
+    static function (): PromiseInterface { return resolve(microtime(true)); },
+])));
+
+assertType('array<bool|float|int>', await(series([
+    static function (): bool { return true; },
+    static function (): int { return time(); },
+    static function (): float { return microtime(true); },
+])));

--- a/tests/types/waterfall.php
+++ b/tests/types/waterfall.php
@@ -1,0 +1,42 @@
+<?php
+
+use React\Promise\PromiseInterface;
+use function PHPStan\Testing\assertType;
+use function React\Async\await;
+use function React\Async\waterfall;
+use function React\Promise\resolve;
+
+assertType('React\Promise\PromiseInterface<null>', waterfall([]));
+
+assertType('React\Promise\PromiseInterface<float>', waterfall([
+    static function (): PromiseInterface { return resolve(microtime(true)); },
+]));
+
+assertType('React\Promise\PromiseInterface<float>', waterfall([
+    static function (): float { return microtime(true); },
+]));
+
+// Desired, but currently unsupported with the current set of templates
+//assertType('React\Promise\PromiseInterface<float>', waterfall([
+//    static function (): PromiseInterface { return resolve(true); },
+//    static function (bool $bool): PromiseInterface { return resolve(time()); },
+//    static function (int $int): PromiseInterface { return resolve(microtime(true)); },
+//]));
+
+assertType('float', await(waterfall([
+    static function (): PromiseInterface { return resolve(microtime(true)); },
+])));
+
+// Desired, but currently unsupported with the current set of templates
+//assertType('float', await(waterfall([
+//    static function (): PromiseInterface { return resolve(true); },
+//    static function (bool $bool): PromiseInterface { return resolve(time()); },
+//    static function (int $int): PromiseInterface { return resolve(microtime(true)); },
+//])));
+
+// assertType('React\Promise\PromiseInterface<null>', waterfall(new EmptyIterator()));
+
+$iterator = new ArrayIterator([
+    static function (): PromiseInterface { return resolve(true); },
+]);
+assertType('React\Promise\PromiseInterface<bool>', waterfall($iterator));


### PR DESCRIPTION
This changeset backports #40 from `4.x` to `3.x` to add type annotations to aid with static analysis. Most changes have been applied as-is, but v3 requires a number of workarounds to support legacy PHP versions.

If this PR is merged, we could backport most of the changes from v3 to v2. The changes are somewhat similar across all versions, but v2 still supports legacy PHP and doesn't currently employ PHPStan as discussed in #77. Let's continue this discussion outside of this PR.

Builds on top of #40 and #77