### PR TITLE
[3.x] Run tests on PHP 8.3 and update test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.3
           - 8.2
           - 8.1
           - 8.0
@@ -19,7 +20,7 @@ jobs:
           - 7.2
           - 7.1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -37,6 +38,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.3
           - 8.2
           - 8.1
           - 8.0
@@ -44,7 +46,7 @@ jobs:
           - 7.3
           - 7.2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "react/promise": "^3.0 || ^2.8 || ^1.2.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.18 || 1.4.10",
-        "phpunit/phpunit": "^9.5 || ^7.5"
+        "phpstan/phpstan": "1.10.39 || 1.4.10",
+        "phpunit/phpunit": "^9.6 || ^7.5"
     },
     "autoload": {
         "files": [
@@ -40,6 +40,8 @@
         ]
     },
     "autoload-dev": {
-        "psr-4": { "React\\Tests\\Async\\": "tests/" }
+        "psr-4": {
+            "React\\Tests\\Async\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.5+ -->
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
          colors="true"
@@ -20,7 +20,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
-        <!-- <ini name="zend.assertions=1" value="1" /> -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old format before PHPUnit 9 -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -18,7 +18,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
-        <!-- <ini name="zend.assertions=1" value="1" /> -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
         <ini name="assert.active" value="1" />
         <ini name="assert.exception" value="1" />
         <ini name="assert.bail" value="0" />

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -3,6 +3,7 @@
 namespace React\Async;
 
 // @codeCoverageIgnoreStart
-if (!function_exists(__NAMESPACE__ . '\\parallel')) {
+if (!\function_exists(__NAMESPACE__ . '\\parallel')) {
     require __DIR__ . '/functions.php';
 }
+// @codeCoverageIgnoreEnd


### PR DESCRIPTION
This changeset backports #81 from `4.x` to `3.x`.

Builds on top of #67 and https://github.com/reactphp/stream/pull/172