### PR TITLE
[4.x] Improve type safety for test environment

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -191,6 +191,7 @@ function async(callable $function): callable
 {
     return static function (mixed ...$args) use ($function): PromiseInterface {
         $fiber = null;
+        /** @var PromiseInterface<T> $promise*/
         $promise = new Promise(function (callable $resolve, callable $reject) use ($function, $args, &$fiber): void {
             $fiber = new \Fiber(function () use ($resolve, $reject, $function, $args, &$fiber): void {
                 try {
@@ -627,6 +628,7 @@ function coroutine(callable $function, mixed ...$args): PromiseInterface
     }
 
     $promise = null;
+    /** @var Deferred<T> $deferred*/
     $deferred = new Deferred(function () use (&$promise) {
         /** @var ?PromiseInterface<T> $promise */
         if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
@@ -685,6 +687,7 @@ function parallel(iterable $tasks): PromiseInterface
 {
     /** @var array<int,PromiseInterface<T>> $pending */
     $pending = [];
+    /** @var Deferred<array<T>> $deferred */
     $deferred = new Deferred(function () use (&$pending) {
         foreach ($pending as $promise) {
             if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
@@ -734,6 +737,7 @@ function parallel(iterable $tasks): PromiseInterface
         $deferred->resolve($results);
     }
 
+    /** @var PromiseInterface<array<T>> Remove once defining `Deferred()` above is supported by PHPStan, see https://github.com/phpstan/phpstan/issues/11032 */
     return $deferred->promise();
 }
 
@@ -745,6 +749,7 @@ function parallel(iterable $tasks): PromiseInterface
 function series(iterable $tasks): PromiseInterface
 {
     $pending = null;
+    /** @var Deferred<array<T>> $deferred */
     $deferred = new Deferred(function () use (&$pending) {
         /** @var ?PromiseInterface<T> $pending */
         if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
@@ -789,6 +794,7 @@ function series(iterable $tasks): PromiseInterface
 
     $next();
 
+    /** @var PromiseInterface<array<T>> Remove once defining `Deferred()` above is supported by PHPStan, see https://github.com/phpstan/phpstan/issues/11032 */
     return $deferred->promise();
 }
 
@@ -800,6 +806,7 @@ function series(iterable $tasks): PromiseInterface
 function waterfall(iterable $tasks): PromiseInterface
 {
     $pending = null;
+    /** @var Deferred<T> $deferred*/
     $deferred = new Deferred(function () use (&$pending) {
         /** @var ?PromiseInterface<T> $pending */
         if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -129,7 +129,7 @@ class AwaitTest extends TestCase
         }
 
         $promise = new Promise(function ($_, $reject) {
-            $reject(false);
+            $reject(false); // @phpstan-ignore-line
         });
 
         $this->expectException(\UnexpectedValueException::class);
@@ -147,7 +147,7 @@ class AwaitTest extends TestCase
         }
 
         $promise = new Promise(function ($_, $reject) {
-            $reject(null);
+            $reject(null); // @phpstan-ignore-line
         });
 
         try {
@@ -331,7 +331,7 @@ class AwaitTest extends TestCase
         gc_collect_cycles();
 
         $promise = new Promise(function ($_, $reject) {
-            $reject(null);
+            $reject(null); // @phpstan-ignore-line
         });
         try {
             $await($promise);


### PR DESCRIPTION
This pull request adds some missing Promise v3 template types that have been reported by PHPStan. The same changes should also be applied to the `3.x` branch, so once this is merged I will create a follow-up PR to do so.

Builds on top of reactphp/promise#247, clue/framework-x/pull/235, #76 and others