### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.1",
         "react/event-loop": "^1.2",
-        "react/promise": "^3.0 || ^2.8 || ^1.2.1"
+        "react/promise": "^3.2 || ^2.8 || ^1.2.1"
     },
     "require-dev": {
         "phpstan/phpstan": "1.10.39",

--- a/src/FiberFactory.php
+++ b/src/FiberFactory.php
@@ -22,7 +22,7 @@ final class FiberFactory
         return (self::factory())();
     }
 
-    public static function factory(\Closure $factory = null): \Closure
+    public static function factory(?\Closure $factory = null): \Closure
     {
         if ($factory !== null) {
             self::$factory = $factory;


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

~~Marking this as WIP until the upstream components have been released. In the meantime, this may use temporary development branches.~~ This change only affects v4, so there is no need to backport these changes to v3 or v2.

Builds on top of #86, #81, #15 and https://github.com/reactphp/promise/pull/260