### PR TITLE
Improve performance by avoiding unneeded references in `FiberMap`

### DIFF
--- a/src/FiberMap.php
+++ b/src/FiberMap.php
@@ -11,23 +11,8 @@ use React\Promise\PromiseInterface;
  */
 final class FiberMap
 {
-    /** @var array<int,bool> */
-    private static array $status = [];
-
     /** @var array<int,PromiseInterface<T>> */
     private static array $map = [];
-
-    /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
-    public static function register(\Fiber $fiber): void
-    {
-        self::$status[\spl_object_id($fiber)] = false;
-    }
-
-    /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
-    public static function cancel(\Fiber $fiber): void
-    {
-        self::$status[\spl_object_id($fiber)] = true;
-    }
 
     /**
      * @param \Fiber<mixed,mixed,mixed,mixed> $fiber
@@ -40,9 +25,8 @@ final class FiberMap
 
     /**
      * @param \Fiber<mixed,mixed,mixed,mixed> $fiber
-     * @param PromiseInterface<T> $promise
      */
-    public static function unsetPromise(\Fiber $fiber, PromiseInterface $promise): void
+    public static function unsetPromise(\Fiber $fiber): void
     {
         unset(self::$map[\spl_object_id($fiber)]);
     }
@@ -54,11 +38,5 @@ final class FiberMap
     public static function getPromise(\Fiber $fiber): ?PromiseInterface
     {
         return self::$map[\spl_object_id($fiber)] ?? null;
-    }
-
-    /** @param \Fiber<mixed,mixed,mixed,mixed> $fiber */
-    public static function unregister(\Fiber $fiber): void
-    {
-        unset(self::$status[\spl_object_id($fiber)], self::$map[\spl_object_id($fiber)]);
     }
 }


### PR DESCRIPTION
This change applies some performance improvements by avoiding unneeded references in the internal `FiberMap`. This is a purely internal change that comes with 100% code coverage and does not otherwise affect the public API, so it should be safe to apply.

This happens to show a ~10% performance improvement in my synthetic benchmark:

```php
async(function () {
    $promise = resolve(42);
    $n = 10_000_000;

    for ($i = 0; $i < $n; ++$i) {
        await($promise);
    }
})();

// old: 3.9s
// new: 3.5s
```

(Also posted in https://twitter.com/another_clue/status/1793723464194638108)

This code path only affects v4, so there is no need to backport this to v3 or v2.

Builds on top of #55 and #20