### PR TITLE
[3.x] Improve type safety for test environment

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -323,6 +323,7 @@ function coroutine(callable $function, ...$args): PromiseInterface
     }
 
     $promise = null;
+    /** @var Deferred<T> $deferred*/
     $deferred = new Deferred(function () use (&$promise) {
         /** @var ?PromiseInterface<T> $promise */
         if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
@@ -381,6 +382,7 @@ function parallel(iterable $tasks): PromiseInterface
 {
     /** @var array<int,PromiseInterface<T>> $pending */
     $pending = [];
+    /** @var Deferred<array<T>> $deferred */
     $deferred = new Deferred(function () use (&$pending) {
         foreach ($pending as $promise) {
             if ($promise instanceof PromiseInterface && \method_exists($promise, 'cancel')) {
@@ -430,6 +432,7 @@ function parallel(iterable $tasks): PromiseInterface
         $deferred->resolve($results);
     }
 
+    /** @var PromiseInterface<array<T>> Remove once defining `Deferred()` above is supported by PHPStan, see https://github.com/phpstan/phpstan/issues/11032 */
     return $deferred->promise();
 }
 
@@ -441,6 +444,7 @@ function parallel(iterable $tasks): PromiseInterface
 function series(iterable $tasks): PromiseInterface
 {
     $pending = null;
+    /** @var Deferred<array<T>> $deferred */
     $deferred = new Deferred(function () use (&$pending) {
         /** @var ?PromiseInterface<T> $pending */
         if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {
@@ -485,6 +489,7 @@ function series(iterable $tasks): PromiseInterface
 
     $next();
 
+    /** @var PromiseInterface<array<T>> Remove once defining `Deferred()` above is supported by PHPStan, see https://github.com/phpstan/phpstan/issues/11032 */
     return $deferred->promise();
 }
 
@@ -496,6 +501,7 @@ function series(iterable $tasks): PromiseInterface
 function waterfall(iterable $tasks): PromiseInterface
 {
     $pending = null;
+    /** @var Deferred<T> $deferred*/
     $deferred = new Deferred(function () use (&$pending) {
         /** @var ?PromiseInterface<T> $pending */
         if ($pending instanceof PromiseInterface && \method_exists($pending, 'cancel')) {

--- a/tests/AwaitTest.php
+++ b/tests/AwaitTest.php
@@ -26,7 +26,7 @@ class AwaitTest extends TestCase
         }
 
         $promise = new Promise(function ($_, $reject) {
-            $reject(false);
+            $reject(false); // @phpstan-ignore-line
         });
 
         $this->expectException(\UnexpectedValueException::class);
@@ -41,7 +41,7 @@ class AwaitTest extends TestCase
         }
 
         $promise = new Promise(function ($_, $reject) {
-            $reject(null);
+            $reject(null); // @phpstan-ignore-line
         });
 
         $this->expectException(\UnexpectedValueException::class);
@@ -278,7 +278,7 @@ class AwaitTest extends TestCase
         gc_collect_cycles();
 
         $promise = new Promise(function ($_, $reject) {
-            $reject(null);
+            $reject(null); // @phpstan-ignore-line
         });
         try {
             React\Async\await($promise);


### PR DESCRIPTION
This changeset backports #86 from `4.x` to `3.x` to add some missing Promise v3 template types that have been reported by PHPStan.

Builds on top of #86, https://github.com/reactphp/promise/pull/247, https://github.com/clue/framework-x/pull/235, https://github.com/reactphp/async/pull/77 and others