### PR TITLE
Run tests on PHP 8.4 and update test environment + PCOV to avoid segfault with Xdebug 3.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -19,17 +20,18 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
 
   PHPStan:
     name: PHPStan (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "react/promise": "^3.2 || ^2.8 || ^1.2.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.10.39",
+        "phpstan/phpstan": "1.12.19",
         "phpunit/phpunit": "^9.6"
     },
     "autoload": {

--- a/tests/types/parallel.php
+++ b/tests/types/parallel.php
@@ -6,7 +6,9 @@ use function React\Async\await;
 use function React\Async\parallel;
 use function React\Promise\resolve;
 
-assertType('React\Promise\PromiseInterface<array>', parallel([]));
+/** @var array<callable():mixed> $emptyArray */
+$emptyArray = [];
+assertType('React\Promise\PromiseInterface<array>', parallel($emptyArray));
 
 assertType('React\Promise\PromiseInterface<array<bool|float|int>>', parallel([
     static fn (): PromiseInterface => resolve(true),

--- a/tests/types/series.php
+++ b/tests/types/series.php
@@ -6,7 +6,9 @@ use function React\Async\await;
 use function React\Async\series;
 use function React\Promise\resolve;
 
-assertType('React\Promise\PromiseInterface<array>', series([]));
+/** @var array<callable():mixed> $emptyArray */
+$emptyArray = [];
+assertType('React\Promise\PromiseInterface<array>', series($emptyArray));
 
 assertType('React\Promise\PromiseInterface<array<bool|float|int>>', series([
     static fn (): PromiseInterface => resolve(true),


### PR DESCRIPTION
Builds on top of #87, #81 and #76.